### PR TITLE
Update Gemfile example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,9 +40,7 @@ detailed in the documentation (using the knife plugin CLI), you should
 install the plugin and supporting libraries from git:
 
 ```ruby
-gem 'fog', :git => 'https://github.com/chrisroberts/fog.git', :ref => 'feature/orchestration'
-gem 'fog-core', :git => 'https://github.com/chrisroberts/fog-core.git', :ref => 'feature/orchestration'
-gem 'knife-cloudformation', :git => 'https://github.com/heavywater/knife-cloudformation.git', :ref => 'feature/fog-model'
+gem 'knife-cloudformation'
 ```
 
 The Knife Cloudformation gem is only needed for stack provisioning via


### PR DESCRIPTION
Since we no longer need magic fog branches, the Gemfile example is now much shorter.
