### PR TITLE
Fix AMI component example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ templates.
 First, create the component (components/ami.rb):
 
 ```ruby
-SparkleFormation.build(:ami) do
+SparkleFormation.build do
 
   mappings.region_map do
     set!('us-east-1', :ami => 'ami-7f418316')


### PR DESCRIPTION
The AMI component example passes a symbol to build. This produces NoMethodError when loaded.
