### PR TITLE
Instance isolation

### DIFF
--- a/.nellie
+++ b/.nellie
@@ -1,0 +1,8 @@
+{
+  "commands": [
+    "apt-get update && apt-get install -qy build-essential",
+    "/opt/chef/embedded/bin/gem install bundler --no-ri --no-rdoc",
+    "/opt/chef/embedded/bin/bundle install --path vendor",
+    "PATH=$PATH:/opt/chef/embedded/bin bundle exec ruby test/spec.rb"
+  ]
+}

--- a/lib/sparkle_formation.rb
+++ b/lib/sparkle_formation.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require 'bogo'
 require 'multi_json'
 require 'attribute_struct'
 

--- a/lib/sparkle_formation.rb
+++ b/lib/sparkle_formation.rb
@@ -21,6 +21,8 @@ require 'attribute_struct'
 
 class SparkleFormation
   autoload :Aws, 'sparkle_formation/aws'
+  autoload :Error, 'sparkle_formation/error'
+  autoload :Sparkle, 'sparkle_formation/sparkle'
   autoload :SparkleAttribute, 'sparkle_formation/sparkle_attribute'
   autoload :SparkleStruct, 'sparkle_formation/sparkle_struct'
   autoload :Utils, 'sparkle_formation/utils'

--- a/lib/sparkle_formation/error.rb
+++ b/lib/sparkle_formation/error.rb
@@ -1,0 +1,24 @@
+require 'sparkle_formation'
+
+class SparkleFormation
+
+  class Error < StandardError
+
+    class NotFound < KeyError
+      attr_reader :name
+
+      def initialize(*args)
+        opts = args.detect{|o| o.is_a?(Hash)}
+        args.delete(opts) if opts
+        super(args)
+        @name = opts[:name] if opts
+      end
+
+      class Dynamic < NotFound; end
+      class Component < NotFound; end
+      class Registry < NotFound; end
+
+    end
+  end
+
+end

--- a/lib/sparkle_formation/error.rb
+++ b/lib/sparkle_formation/error.rb
@@ -17,6 +17,7 @@ class SparkleFormation
       class Dynamic < NotFound; end
       class Component < NotFound; end
       class Registry < NotFound; end
+      class Template < NotFound; end
 
     end
   end

--- a/lib/sparkle_formation/sparkle.rb
+++ b/lib/sparkle_formation/sparkle.rb
@@ -213,6 +213,9 @@ class SparkleFormation
       end
       result = send(TYPES[type])[name]
       unless(result)
+        result = (send(TYPES[type]).detect{|k,v| v[:path] == name} || []).last
+      end
+      unless(result)
         klass = Error::NotFound.const_get(type.capitalize)
         raise klass.new("No #{type} registered with requested name (#{name})!", :name => name)
       end

--- a/lib/sparkle_formation/sparkle.rb
+++ b/lib/sparkle_formation/sparkle.rb
@@ -14,6 +14,8 @@ class SparkleFormation
 
         class SparkleFormation
 
+          attr_accessor :sparkle_path
+
           class << self
 
             def part_data(data=nil)

--- a/lib/sparkle_formation/sparkle.rb
+++ b/lib/sparkle_formation/sparkle.rb
@@ -68,6 +68,14 @@ class SparkleFormation
       'dynamics'
     ]
 
+    # Valid types
+    TYPES = [
+      'component',
+      'registry',
+      'dynamic',
+      'template'
+    ]
+
     # @return [String] path to sparkle directories
     attr_reader :root
 
@@ -127,10 +135,26 @@ class SparkleFormation
             slim_path = path.sub("#{root}/", '')
             next if DIRS.include?(slim_path.split('/').first)
             name = slim_path.tr('/', '__')
-            hash[name] = path
+            hash[name] = Smash.new(
+              :path => path,
+              :type => :template
+            )
           end
         end
       end
+    end
+
+    # Request item from the store
+    #
+    # @param type [String, Symbol] item type (see: TYPES)
+    # @param name [String, Symbol] name of item
+    # @return [Smash] requested item
+    # @raises [NameError, KeyError]
+    def get(type, name)
+      unless(TYPES.include?(type.to_s))
+        raise NameError.new "Invalid type requested (#{type})! Valid types: #{TYPES.join(', ')}"
+      end
+      send(type)[name] || KeyError.new "No #{type} registered with requested name (#{name})!"
     end
 
     private

--- a/lib/sparkle_formation/sparkle.rb
+++ b/lib/sparkle_formation/sparkle.rb
@@ -1,0 +1,46 @@
+require 'sparkle_formation'
+
+class SparkleFormation
+  class Sparkle
+
+    include Bogo::Memoization
+
+    # @return [String] path to sparkle directories
+    attr_reader :root
+
+    # Create new sparkle instance
+    #
+    # @param args [Hash]
+    # @option args [String] :root path to sparkle directories
+    # @return [self]
+    def initialize(args={})
+      @root = args.fetch(:root, Dir.pwd)
+    end
+
+    # @return [Smash<name:block>]
+    def components
+      memoize(:components) do
+
+      end
+    end
+
+    # @return [Smash<name:block>]
+    def dynamics
+      memoize(:dynamics) do
+      end
+    end
+
+    # @return [Smash<name:block>]
+    def registries
+      memoize(:registries) do
+      end
+    end
+
+    # @return [Smash<name:SparkleFormation>]
+    def templates
+      memoize(:templates) do
+      end
+    end
+
+  end
+end

--- a/lib/sparkle_formation/sparkle.rb
+++ b/lib/sparkle_formation/sparkle.rb
@@ -3,7 +3,70 @@ require 'sparkle_formation'
 class SparkleFormation
   class Sparkle
 
+    # Wrapper for evaluating sfn files to store within sparkle
+    # container and remove global application
+    class EvalWrapper < BasicObject
+      class SparkleFormation
+
+        def self.dynamic(name, args={}, &block)
+          ::Smash.new(
+            :name => name,
+            :block => block,
+            :args => Smash[
+              args.map(&:to_a)
+            ],
+            :type => :dynamic
+          )
+        end
+
+        def self.build(&block)
+          ::Smash.new(
+            :block => block,
+            :type => :component
+          )
+        end
+
+        def self.component(name, &block)
+          ::Smash.new(
+            :name => name,
+            :block => block,
+            :type => :component
+          )
+        end
+
+        class Registry
+
+          def self.register(name, &block)
+            ::Smash.new(
+              :name => name,
+              :block => block,
+              :type => :registry
+            )
+          end
+
+        end
+        SfnRegistry = Registry
+
+      end
+    end
+
     include Bogo::Memoization
+
+    # Valid directories from cwd to set as root
+    VALID_ROOT_DIRS = [
+      'sparkleformation',
+      'sfn',
+      'cloudformation',
+      'cfn',
+      '.'
+    ]
+
+    # Reserved directories
+    DIRS = [
+      'components',
+      'registries',
+      'dynamics'
+    ]
 
     # @return [String] path to sparkle directories
     attr_reader :root
@@ -14,32 +77,75 @@ class SparkleFormation
     # @option args [String] :root path to sparkle directories
     # @return [self]
     def initialize(args={})
-      @root = args.fetch(:root, Dir.pwd)
+      @root = args.fetch(:root, locate_root)
     end
 
     # @return [Smash<name:block>]
     def components
       memoize(:components) do
-
+        Smash.new.tap do |hash|
+          Dir.glob(File.join(root, 'components', '*.rb')) do |file|
+            result = EvalWrapper.new.instance_eval(IO.read(file), file, 1)
+            unless(result[:name])
+              result[:name] = File.basename(file).sub('.rb', '')
+            end
+            hash[result.delete(:name)] = result
+          end
+        end
       end
     end
 
     # @return [Smash<name:block>]
     def dynamics
       memoize(:dynamics) do
+        Smash.new.tap do |hash|
+          Dir.glob(File.join(root, 'dynamics', '*.rb')) do |file|
+            dyn = EvalWrapper.new.instance_eval(IO.read(file), file, 1)
+            hash[dyn.delete(:name)] = dyn
+          end
+        end
       end
     end
 
     # @return [Smash<name:block>]
     def registries
       memoize(:registries) do
+        Smash.new.tap do |hash|
+          Dir.glob(File.join(root, 'registries', '*.rb')) do |file|
+            reg = EvalWrapper.new.instance_eval(IO.read(file), file, 1)
+            hash[reg.delete(:name)] = reg
+          end
+        end
       end
     end
 
-    # @return [Smash<name:SparkleFormation>]
+    # @return [Smash<name:path>]
     def templates
       memoize(:templates) do
+        Smash.new.tap do |hash|
+          Dir.glob(File.join(root, '**', '**', '*.{json,rb}')) do |path|
+            slim_path = path.sub("#{root}/", '')
+            next if DIRS.include?(slim_path.split('/').first)
+            name = slim_path.tr('/', '__')
+            hash[name] = path
+          end
+        end
       end
+    end
+
+    private
+
+    # Locate root directory. Defaults to current working directory if
+    # valid sub directory is not located
+    #
+    # @return [String] root path
+    def locate_root
+      VALID_ROOT_DIRS.map do |part|
+        path = File.expand_path(File.join(Dir.pwd, part))
+        if(File.exists?(path))
+          path
+        end
+      end.compact.first
     end
 
   end

--- a/lib/sparkle_formation/sparkle_attribute.rb
+++ b/lib/sparkle_formation/sparkle_attribute.rb
@@ -308,7 +308,7 @@ class SparkleFormation
     # @param args [Object] argument list for dynamic
     # @return [self]
     def dynamic!(name, *args, &block)
-      _self.insert(name, self, *args, &block)
+      SparkleFormation.insert(name, self, *args, &block)
     end
 
     # Registry insertion helper method
@@ -317,7 +317,7 @@ class SparkleFormation
     # @param args [Object] argument list for registry
     # @return [self]
     def registry!(name, *args)
-      _self.registry.insert(name, self, *args)
+      SparkleFormation::Registry.insert(name, self, *args)
     end
 
     # Stack nesting helper method
@@ -326,7 +326,7 @@ class SparkleFormation
     # @param args [String, Symbol] stringified and underscore joined for name
     # @return [self]
     def nest!(template, *args, &block)
-      _self.nest(template, self, *args, &block)
+      SparkleFormation.nest(template, self, *args, &block)
     end
 
   end

--- a/lib/sparkle_formation/sparkle_attribute.rb
+++ b/lib/sparkle_formation/sparkle_attribute.rb
@@ -308,7 +308,7 @@ class SparkleFormation
     # @param args [Object] argument list for dynamic
     # @return [self]
     def dynamic!(name, *args, &block)
-      SparkleFormation.insert(name, self, *args, &block)
+      _self.insert(name, self, *args, &block)
     end
 
     # Registry insertion helper method
@@ -317,7 +317,7 @@ class SparkleFormation
     # @param args [Object] argument list for registry
     # @return [self]
     def registry!(name, *args)
-      SfnRegistry.insert(name, self, *args)
+      _self.registry.insert(name, self, *args)
     end
 
     # Stack nesting helper method
@@ -326,7 +326,7 @@ class SparkleFormation
     # @param args [String, Symbol] stringified and underscore joined for name
     # @return [self]
     def nest!(template, *args, &block)
-      SparkleFormation.nest(template, self, *args, &block)
+      _self.nest(template, self, *args, &block)
     end
 
   end

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -253,7 +253,7 @@ class SparkleFormation
         _config ||= {}
         return unless _name
         resource_name = "#{_name}_#{_config.delete(:resource_name_suffix) || dynamic_name}".to_sym
-        new_resource = struct.resources.__send__(resource_name)
+        new_resource = struct.resources[resource_name]
         new_resource.type lookup_key
         properties = new_resource.properties
         SfnAws.resource(dynamic_name, :properties).each do |prop_name|
@@ -262,9 +262,9 @@ class SparkleFormation
           end.compact.first
           if(value)
             if(value.is_a?(Proc))
-              properties.__send__(prop_name).instance_exec(&value)
+              properties[prop_name].to_sym.instance_exec(&value)
             else
-              properties.__send__(prop_name, value)
+              properties.set!(prop_name, value)
             end
           end
         end

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -106,7 +106,13 @@ class SparkleFormation
     #   to pass through when compiling ({:state => {}})
     # @return [Hashish, SparkleStruct]
     def compile(path, *args)
-      formation = self.instance_eval(IO.read(path), path, 1)
+      opts = args.detect{|i| i.is_a?(Hash) }
+      if(opts[:sparkle_path])
+        container = Sparkle.new(:root => opts[:sparkle_path])
+        formation = container.get(:template, path)
+      else
+        formation = self.instance_eval(IO.read(path), path, 1)
+      end
       if(args.delete(:sparkle))
         formation
       else

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -107,12 +107,11 @@ class SparkleFormation
     # @return [Hashish, SparkleStruct]
     def compile(path, *args)
       opts = args.detect{|i| i.is_a?(Hash) } || {}
-      if(opts[:sparkle_path])
-        container = Sparkle.new(:root => opts[:sparkle_path])
-        formation = container.get(:template, path)
-      else
-        formation = self.instance_eval(IO.read(path), path, 1)
+      if(spath = opts.fetch(:sparkle_path, SparkleFormation.sparkle_path))
+        container = Sparkle.new(:root => spath)
+        path = container.get(:template, path)[:path]
       end
+      formation = self.instance_eval(IO.read(path), path, 1)
       if(args.delete(:sparkle))
         formation
       else

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -123,7 +123,7 @@ class SparkleFormation
     def build(base=nil, &block)
       struct = base || SparkleStruct.new
       struct.instance_exec(&block)
-      @_struct = struct
+      struct
     end
 
     # Load component
@@ -253,6 +253,7 @@ class SparkleFormation
         _config ||= {}
         return unless _name
         resource_name = "#{_name}_#{_config.delete(:resource_name_suffix) || dynamic_name}".to_sym
+        struct.resources.set!(resource_name)
         new_resource = struct.resources[resource_name]
         new_resource.type lookup_key
         properties = new_resource.properties
@@ -324,8 +325,11 @@ class SparkleFormation
     @component_paths = []
     @sparkle = Sparkle.new(
       Smash.new.tap{|h|
-        if(options[:sparkle_path])
-          h[:root] = options[:sparkle_path]
+        s_path = options.fetch(:sparkle_path,
+          self.class.custom_paths[:sparkle_path]
+        )
+        if(s_path)
+          h[:root] = s_path
         end
       }
     )
@@ -387,7 +391,8 @@ class SparkleFormation
       else
         struct = SparkleStruct.new
         struct._set_self(self)
-        components[key] = struct.instance_exec(&sparkle.get(:component, thing)[:block])
+        struct.instance_exec(&sparkle.get(:component, thing)[:block])
+        components[key] = struct
       end
       @load_order << key
     end

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -239,7 +239,7 @@ class SparkleFormation
       struct.resources.set!(resource_name) do
         type 'AWS::CloudFormation::Stack'
       end
-      struct.resources[resource_name].properties.stack nested_template.compile
+      struct.resources[resource_name].properties.stack nested_template
       if(block_given?)
         struct.resources[resource_name].instance_exec(&block)
       end
@@ -378,7 +378,9 @@ class SparkleFormation
   # @param block [Proc]
   # @return [TrueClass]
   def block(block)
-    @components[:__base__] = self.class.build(&block)
+    struct = SparkleStruct.new
+    struct._set_self(self)
+    @components[:__base__] = self.class.build(struct, &block)
     @load_order << :__base__
     true
   end

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -293,6 +293,8 @@ class SparkleFormation
     end
   end
 
+  include Bogo::Memoization
+
   # @return [Symbol] name of formation
   attr_reader :name
   # @return [String] base path
@@ -323,6 +325,9 @@ class SparkleFormation
   # @yield base context
   def initialize(name, options={}, &block)
     @name = name.to_sym
+    @component_paths = []
+
+
     @sparkle_path = options[:sparkle_path] ||
       self.class.custom_paths[:sparkle_path] ||
       File.join(Dir.pwd, 'cloudformation')
@@ -349,6 +354,19 @@ class SparkleFormation
       load_block(block)
     end
     @compiled = nil
+  end
+
+  # @return [Smash] currently set paths
+  def paths
+    {
+      :sparkle_path => sparkle_path,
+      :components => component_paths,
+      :registries => registry_paths,
+      :dynamics => dynamic_paths
+    }
+  end
+
+  def component_paths
   end
 
   ALLOWED_GENERATION_PARAMETERS = ['type', 'default']

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -418,6 +418,7 @@ class SparkleFormation
   def compile(args={})
     unless(@compiled)
       compiled = SparkleStruct.new
+      compiled._self(self)
       if(args[:state])
         compiled.set_state!(args[:state])
       end

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -106,7 +106,7 @@ class SparkleFormation
     #   to pass through when compiling ({:state => {}})
     # @return [Hashish, SparkleStruct]
     def compile(path, *args)
-      opts = args.detect{|i| i.is_a?(Hash) }
+      opts = args.detect{|i| i.is_a?(Hash) } || {}
       if(opts[:sparkle_path])
         container = Sparkle.new(:root => opts[:sparkle_path])
         formation = container.get(:template, path)

--- a/lib/sparkle_formation/sparkle_struct.rb
+++ b/lib/sparkle_formation/sparkle_struct.rb
@@ -20,9 +20,14 @@ class SparkleFormation
     # @return [SparkleFormation]
     def _self
       unless(@self)
-        raise 'Creator did not provide return reference!'
+        if(_parent.nil?)
+          raise 'Creator did not provide return reference!'
+        else
+          _parent._self
+        end
+      else
+        @self
       end
-      @self
     end
 
     # @return [Class]

--- a/lib/sparkle_formation/sparkle_struct.rb
+++ b/lib/sparkle_formation/sparkle_struct.rb
@@ -11,17 +11,17 @@ class SparkleFormation
     # @param inst [SparkleFormation]
     # @return [SparkleFormation]
     def _set_self(inst)
-      unless(inst.is_a?(SparkleFormation))
-        raise TypeError.new "Expecting type of `SparkleFormation` but got `#{inst.class}`"
+      unless(inst.is_a?(::SparkleFormation))
+        ::Kernel.raise ::TypeError.new "Expecting type of `SparkleFormation` but got `#{inst.class}`"
       end
       @self = inst
     end
 
     # @return [SparkleFormation]
-    def _self
+    def _self(*_)
       unless(@self)
         if(_parent.nil?)
-          raise 'Creator did not provide return reference!'
+          ::Kernel.raise ::ArgumentError.new 'Creator did not provide return reference!'
         else
           _parent._self
         end
@@ -34,5 +34,6 @@ class SparkleFormation
     def _klass
       ::SparkleFormation::SparkleStruct
     end
+
   end
 end

--- a/lib/sparkle_formation/sparkle_struct.rb
+++ b/lib/sparkle_formation/sparkle_struct.rb
@@ -6,6 +6,25 @@ class SparkleFormation
     include ::SparkleFormation::SparkleAttribute
     # @!parse include ::SparkleFormation::SparkleAttribute
 
+    # Set SparkleFormation instance
+    #
+    # @param inst [SparkleFormation]
+    # @return [SparkleFormation]
+    def _set_self(inst)
+      unless(inst.is_a?(SparkleFormation))
+        raise TypeError.new "Expecting type of `SparkleFormation` but got `#{inst.class}`"
+      end
+      @self = inst
+    end
+
+    # @return [SparkleFormation]
+    def _self
+      unless(@self)
+        raise 'Creator did not provide return reference!'
+      end
+      @self
+    end
+
     # @return [Class]
     def _klass
       ::SparkleFormation::SparkleStruct

--- a/sparkle_formation.gemspec
+++ b/sparkle_formation.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.add_dependency 'attribute_struct', '~> 0.2.2'
   s.add_dependency 'multi_json'
+  s.add_dependency 'bogo'
   s.executables << 'generate_sparkle_docs'
   s.files = Dir['lib/**/*'] + %w(sparkle_formation.gemspec README.md CHANGELOG.md LICENSE)
 end

--- a/test/specs/basic_spec.rb
+++ b/test/specs/basic_spec.rb
@@ -1,5 +1,9 @@
 describe SparkleFormation do
 
+  before do
+    SparkleFormation.sparkle_path = File.join(File.dirname(__FILE__), 'cloudformation')
+  end
+
   describe 'Basic Usage' do
 
     it 'should dump hashes' do

--- a/test/specs/basic_spec.rb
+++ b/test/specs/basic_spec.rb
@@ -55,6 +55,13 @@ describe SparkleFormation do
       end.dump.must_equal full_stack
     end
 
+    it 'should load dynamics via deprecated inserts' do
+      full_stack = MultiJson.load(File.read(File.join(File.dirname(__FILE__), 'results', 'base.json')))
+      SparkleFormation.new(:dummy).load(:ami).overrides do
+        SparkleFormation.insert(:node, self, :my)
+      end.dump.to_smash(:sorted).must_equal full_stack.to_smash(:sorted)
+    end
+
     it 'should allow dynamic customization' do
       full_stack = MultiJson.load(File.read(File.join(File.dirname(__FILE__), 'results', 'base_with_map.json')))
       SparkleFormation.new(:dummy).load(:ami).overrides do

--- a/test/specs/basic_spec.rb
+++ b/test/specs/basic_spec.rb
@@ -12,9 +12,14 @@ describe SparkleFormation do
       end.dump.must_equal 'Test' => true
     end
 
-    it 'should include components' do
+    it 'should include file named components' do
       SparkleFormation.new(:dummy).load(:ami).
         dump.keys.must_include 'Mappings'
+    end
+
+    it 'should include explicitly named components' do
+      SparkleFormation.new(:dummy).load(:user_info).
+        dump.keys.must_include 'Parameters'
     end
 
     it 'should process overrides' do

--- a/test/specs/cloudformation/components/creator.rb
+++ b/test/specs/cloudformation/components/creator.rb
@@ -1,0 +1,10 @@
+SparkleFormation.component(:user_info) do
+  parameters.creator do
+    type 'String'
+    default 'Fubar'
+  end
+  output.creator do
+    description 'Stack creator'
+    value ref!(:creator)
+  end
+end

--- a/test/specs/cloudformation/dummy.rb
+++ b/test/specs/cloudformation/dummy.rb
@@ -1,0 +1,3 @@
+SparkleFormation.new('dummy').load(:user_info).overrides do
+  outputs.dummy.value 'Dummy value'
+end

--- a/test/specs/cloudformation/nest.rb
+++ b/test/specs/cloudformation/nest.rb
@@ -1,0 +1,4 @@
+SparkleFormation.new('nest') do
+  nest!(:dummy)
+  nest!(:simple)
+end

--- a/test/specs/cloudformation/simple.rb
+++ b/test/specs/cloudformation/simple.rb
@@ -1,4 +1,4 @@
-SparkleFormation.new('simple').load(:user_info).overloads do
+SparkleFormation.new('simple').load(:user_info).overrides do
   dynamic!(:node, 'fubar')
   outputs.region do
     description 'Region of stack'

--- a/test/specs/cloudformation/simple.rb
+++ b/test/specs/cloudformation/simple.rb
@@ -1,0 +1,7 @@
+SparkleFormation.new('simple').load(:user_info).overloads do
+  dynamic!(:node, 'fubar')
+  outputs.region do
+    description 'Region of stack'
+    value region!
+  end
+end

--- a/test/specs/template_spec.rb
+++ b/test/specs/template_spec.rb
@@ -4,11 +4,30 @@ describe SparkleFormation do
     SparkleFormation.sparkle_path = File.join(File.dirname(__FILE__), 'cloudformation')
   end
 
-  describe 'Simple template' do
+  describe 'Dummy template' do
 
-    it 'should build the template' do
-      SparkleFormation.compile('dummy.rb')
+    it 'should build the dummy template' do
+      result = SparkleFormation.compile('dummy.rb')
+      result.must_be :is_a?, Hash
+      result.to_smash.get('Outputs', 'Dummy', 'Value').must_equal 'Dummy value'
+      result.to_smash.get('Parameters', 'Creator', 'Default').must_equal 'Fubar'
     end
 
   end
+
+  describe 'Nested template' do
+
+    it 'should build the nested template' do
+      result = SparkleFormation.compile('nest.rb')
+      simple = SparkleFormation.compile('simple.rb')
+      dummy = SparkleFormation.compile('dummy.rb')
+      result.must_be :is_a?, Hash
+      simple.must_be :is_a?, Hash
+      dummy.must_be :is_a?, Hash
+      result.to_smash.get('Resources', 'Dummy', 'Properties', 'Stack').to_json.must_equal dummy.to_smash.to_json
+      result.to_smash.get('Resources', 'Simple', 'Properties', 'Stack').to_json.must_equal simple.to_smash.to_json
+    end
+
+  end
+
 end

--- a/test/specs/template_spec.rb
+++ b/test/specs/template_spec.rb
@@ -1,0 +1,14 @@
+describe SparkleFormation do
+
+  before do
+    SparkleFormation.sparkle_path = File.join(File.dirname(__FILE__), 'cloudformation')
+  end
+
+  describe 'Simple template' do
+
+    it 'should build the template' do
+      SparkleFormation.compile('dummy.rb')
+    end
+
+  end
+end


### PR DESCRIPTION
This removes global storage of items loaded from local sfn implementations. Moves to storing them in isolated "containers" that a `SparkleFormation` instance keeps locally. This allows multiple `SparkleFormation` instances to be created at once with differing root directories.

Covers request in #39 