### PR TITLE
SparkleCollection add/remove manipulating computed array

### DIFF
--- a/lib/sparkle_formation/sparkle_collection.rb
+++ b/lib/sparkle_formation/sparkle_collection.rb
@@ -32,9 +32,9 @@ class SparkleFormation
         raise TypeError.new "Expected type `SparkleFormation::Sparkle` but received `#{sparkle.class}`!"
       end
       if(precedence == :high)
-        sparkles.push(sparkle).uniq!
+        @sparkles.push(sparkle).uniq!
       else
-        sparkles.unshift(sparkle).uniq!
+        @sparkles.unshift(sparkle).uniq!
       end
       self
     end
@@ -44,7 +44,7 @@ class SparkleFormation
     # @param sparkle [Sparkle]
     # @return [self]
     def remove_sparkle(sparkle)
-      sparkles.delete(sparkle)
+      @sparkles.delete(sparkle)
       self
     end
 


### PR DESCRIPTION
Quick change to ensure we add/remove from the internal @sparkles array rather than the result of @sparkles + [@root].

On a completely unrelated note, I noticed the docs point towards having a "registries" vs a "registry" directory. If this is intentional, then maybe SparklePack::DIRS should be modified to reflect this.

And lastly .. this new work is so awesome, thank you. 