### PR TITLE
Add minitest as a dev dependency

### DIFF
--- a/sparkle_formation.gemspec
+++ b/sparkle_formation.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'attribute_struct', '~> 0.2.2'
   s.add_dependency 'multi_json'
   s.add_dependency 'bogo'
+  s.add_development_dependency 'minitest'
   s.executables << 'generate_sparkle_docs'
   s.files = Dir['lib/**/*'] + %w(sparkle_formation.gemspec README.md CHANGELOG.md LICENSE)
 end


### PR DESCRIPTION
Otherwise bundle exec will fail since minitest isn't in the gem space.