### PR TITLE
Documentation updates for the new sparkleformation website

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,19 @@
+---
+title: "Overview"
+category: "dsl"
+weight: 1
+next:
+  label: "SparkleFormation DSL"
+  url: "sparkleformation-dsl"
+---
+
 # Overview
 
 SparkleFormation is a Ruby DSL library that assists in programmatically
 composing template files commonly used by orchestration APIs. The library
-has specific helper methods defined targeting the AWS CloudFormation
-API, but the library is _not_ restricted to generating only AWS CloudFormation
-templates.
+has specific helper methods defined targeting the [AWS CloudFormation][cfn]
+API, but the library is _not_ restricted to generating only
+[AWS CloudFormation][cfn] templates.
 
 SparkleFormation templates describe the state of infrastructure resources
 as code. This allows for provisioning and updating of isolated stacks of
@@ -19,29 +28,29 @@ AWS, Rackspace, OpenStack, GCE, and other similar services.
 ## Table of Contents
 
 - [Getting Started](#getting-started)
-- [The DSL](sparkleformation-dsl.md)
-  - [Behavior](sparkleformation-dsl.md#behavior)
-  - [Features](sparkleformation-dsl.md#features)
-- [Building Blocks](building-blocks.md)
-  - [Components](building-blocks.md#components)
-  - [Dynamics](building-blocks.md#dynamics)
-  - [Registry](building-blocks.md#registry)
-  - [Templates](building-blocks.md#templates)
-- [Template Anatomy](anatomy.md)
-  - [Base Attributes](anatomy.md#base-attributes)
-  - [Parameters](anatomy.md#parameters)
-  - [Mappings](anatomy.md#mappings)
-  - [Conditions](anatomy.md#conditions)
-  - [Resources](anatomy.md#resources)
-  - [Outputs](anatomy.md#outputs)
+- [The DSL](sparkleformation-dsl)
+  - [Behavior](sparkleformation-dsl#behavior)
+  - [Features](sparkleformation-dsl#features)
+- [Building Blocks](building-blocks)
+  - [Components](building-blocks#components)
+  - [Dynamics](building-blocks#dynamics)
+  - [Registry](building-blocks#registry)
+  - [Templates](building-blocks#templates)
+- [Template Anatomy](anatomy)
+  - [Base Attributes](anatomy#base-attributes)
+  - [Parameters](anatomy#parameters)
+  - [Mappings](anatomy#mappings)
+  - [Conditions](anatomy#conditions)
+  - [Resources](anatomy#resources)
+  - [Outputs](anatomy#outputs)
 - Library Features
-  - [Helper Methods](helper-methods.md)
-  - [Nested Stacks](nested-stacks.md)
-    - [Shallow Nesting](nested-stacks.md#shallow-nesting)
-    - [Deep Nesting](nested-stacks.md#deep-nesting)
-  - [Sparkle Packs](sparkle-packs.md)
-  - [Stack Policies](stack-policies.md)
-  - [Translation](translation.md)
+  - [Helper Methods](helper-methods)
+  - [Nested Stacks](nested-stacks)
+    - [Shallow Nesting](nested-stacks#shallow-nesting)
+    - [Deep Nesting](nested-stacks#deep-nesting)
+  - [Sparkle Packs](sparkle-packs)
+  - [Stack Policies](stack-policies)
+  - [Translation](translation)
 
 ## Getting Started
 
@@ -49,4 +58,7 @@ SparkleFormation on its own is simply a library used to generate serialized
 templates. This documentation is focused mainly on the library specific
 features and functionality. For user documentation focused on building and
 generating infrastructure with SparkleFormation, please refer to the
-sfn documentation.
+[sfn][sfn] documentation.
+
+[cfn]: https://aws.amazon.com/cloudformation/
+[sfn]: ../../sfn/

--- a/docs/anatomy.md
+++ b/docs/anatomy.md
@@ -1,3 +1,20 @@
+---
+title: "Template Anatomy"
+category: "dsl"
+weight: 4
+anchors:
+  - title: "Parameters"
+    url: "#parameters"
+  - title: "Mappings"
+    url: "#mappings"
+  - title: "Conditions"
+    url: "#conditions"
+  - title: "Resources"
+    url: "#resources"
+  - title: "Outputs"
+    url: "#outputs"  
+---
+
 ## Template Anatomy
 
 The anatomy of a template is dependent on the specific implementation that is
@@ -20,13 +37,13 @@ style template as it is the most widely implemented.
 All templates must begin with the expected API version and may include a description
 and or metadata:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template) do
   set!('AWSTemplateFormatVersion', '2010-09-09')
   description 'My New Stack'
   metadata.instances.description 'Awesome instances'
 end
-```
+~~~
 
 * [Format Version](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html)
 * [Description](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-description-structure.html)
@@ -38,7 +55,7 @@ Parameters are named variables available within the template that users may
 provide customized values when creating or updating a stack. This allows
 "runtime" modifications to occur when the template is evaluated by the API.
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template) do
   parameters do
     creator do
@@ -47,7 +64,7 @@ SparkleFormation.new(:template) do
     end
   end
 end
-```
+~~~
 
 * [Parameters](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)
 
@@ -57,24 +74,24 @@ Mappings are a nested key/value store. They provide an easy way to dynamically
 specify what value should be used based on context available when the template
 is evaluated by the API.
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template) do
   mappings.platforms.set!('us-west-2'._no_hump) do
     centos6 'ami-b6bdde86'
     centos7 'ami-c7d092f7'
   end
 end
-```
+~~~
 
 These can then be referenced using the `map!` helper method:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template) do
   dynamic!(:ec2_instance, :foobar) do
     properties.image_id map!(:platforms, region!, :centos7)
   end
 end
-```
+~~~
 
 * [Mappings](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/mappings-section-structure.html)
 * [Fn::FindInMap](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-findinmap.html)
@@ -87,7 +104,7 @@ properties values or to allow/restrict the creation of resources and
 outputs.
 
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template) do
   parameters.creator do
     type 'String'
@@ -97,11 +114,11 @@ SparkleFormation.new(:template) do
     creator_is_spox equals!(ref!(:creator), 'spox')
   end
 end
-```
+~~~
 
 This condition can then be used to provide a custom value for a property:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template) do
   parameters.creator do
     type 'String'
@@ -114,11 +131,11 @@ SparkleFormation.new(:template) do
     key_name if!(:creator_is_spox, 'spox-key', 'default')
   end
 end
-```
+~~~
 
 The condition can also be used to restrict the creation of a resource:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template) do
   parameters.creator do
     type 'String'
@@ -131,7 +148,7 @@ SparkleFormation.new(:template) do
     on_condition :creator_is_spox
   end
 end
-```
+~~~
 
 * [Conditions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html)
 * [Condition Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html)
@@ -141,7 +158,7 @@ end
 Resources are the infrastructure items and configurations to be
 provisioned by the orchestration API:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template) do
   resources.my_instance do
     type 'AWS::EC2::Instance'
@@ -151,7 +168,7 @@ SparkleFormation.new(:template) do
     end
   end
 end
-```
+~~~
 
 * [Resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html)
 
@@ -160,7 +177,7 @@ end
 Outputs are resultant values from the provisioned infrastructure stack.
 It generally contains information about specific resource attributes.
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template) do
   outputs do
     instance_address do
@@ -169,11 +186,11 @@ SparkleFormation.new(:template) do
     end
   end
 end
-```
+~~~
 
 Conditions can also be applied on outputs:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template) do
   outputs do
     instance_address do
@@ -183,6 +200,6 @@ SparkleFormation.new(:template) do
     end
   end
 end
-```
+~~~
 
 * [Outputs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html)

--- a/docs/helper-methods.md
+++ b/docs/helper-methods.md
@@ -1,3 +1,20 @@
+---
+title: "Helper Methods"
+category: "dsl"
+weight: 5
+anchors:
+  - title: "Dynamics"
+    url: "#dynamics"
+  - title: "Registries"
+    url: "#registries"
+  - title: "Nests"
+    url: "#nests"
+  - title: "Local System Call"
+    url: "#local-system-call"
+  - title: "AWS Helpers"
+    url: "#aws-helpers"
+---
+
 ## Helper methods
 
 SparkleFormation provides a collection of helper methods
@@ -14,57 +31,57 @@ Inserting a dynamic directly requires calling out to the
 singleton method and providing the local context, which
 looks like this:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   SparkleFormation.insert(:my_dynamic, self, :some => [:value])
 end
-```
+~~~
 
 The helper compacts this call to:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   dynamic!(:my_dynamic, :some => [:value])
 end
-```
+~~~
 
 #### Registries
 
 Registries are used by calling out the singleton method and
 providing the local context:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   SparkleFormation::Registry.insert(:my_registry, self, :some => [:value])
 end
-```
+~~~
 
 and can be compacted to:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   registry!(:my_registry, :some => [:value])
 end
-```
+~~~
 
 #### Nests
 
 Nests are used by calling out to the singleton method and
 providing the local context:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   SparkleFormation.nest(:my_template, self, :some => [:value])
 end
-```
+~~~
 
 and can be compacted to:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   nest!(:my_template, :some => [:value])
 end
-```
+~~~
 
 #### Other
 
@@ -73,11 +90,11 @@ end
 Use the `system!` helper method to shell out to the local system,
 execute a command, and return the string output:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   parameters.creator.default system!('whoami')
 end
-```
+~~~
 
 ### Generation Helpers
 
@@ -120,21 +137,21 @@ Helpers for using conditions:
 
 * `if!(CONDITION_NAME)`
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
 ...
   some_value if!(:my_condition, TRUE_VALUE, FALSE_VALUE)
 ...
 end
-```
+~~~
 
 * `on_condition!(CONDITION_NAME)`
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
 ...
   resources.my_cool_resource do
     on_condition!(:stack_is_cool)
 ...
 end
-```
+~~~

--- a/docs/nested-stacks.md
+++ b/docs/nested-stacks.md
@@ -1,3 +1,14 @@
+---
+title: "Nested Stacks"
+category: "dsl"
+weight: 6
+anchors:
+  - title: "Shallow Nesting"
+    url: "#shallow-nesting"
+  - title: "Deep Nesting"
+    url: "#deep-nesting"
+---
+
 ## Nested Stacks
 
 Most orchestration API templating systems provide support for a
@@ -14,12 +25,12 @@ The interface for using SparkleFormation's nested stack functionality
 is via the `nest!` helper method. The method accepts a template
 name and will insert the stack resource into the current template:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:root_template) do
   nest!(:networking)
   nest!(:applications)
 end
-```
+~~~
 
 ### Shallow Nesting
 
@@ -46,7 +57,7 @@ order. It will first extract parameter names from the nested stack. If
 the root stack has no matching parameter, the parameter will automatically
 be added to the root stack. For example:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template_a) do
   ...
   parameters.fubar do
@@ -54,17 +65,17 @@ SparkleFormation.new(:template_a) do
     default 'FOOBAR'
   end
 end
-```
+~~~
 
-```ruby
+~~~ruby
 SparkleFormation.new(:root) do
   nest!(:template_a)
 end
-```
+~~~
 
 when when compiled would result in:
 
-```json
+~~~json
 ...
   "Parameters": {
     "Fubar": {
@@ -80,8 +91,9 @@ when when compiled would result in:
           "Fubar": {
             "Ref": "Fubar"
           }
+
 ...
-```
+~~~
 
 If a second stack is nested and it defines a parameter
 with the same name as a previously defined parameter,
@@ -101,7 +113,7 @@ matches the name of an output defined in a nested stack, SparkleFormation
 will automatically update the nested stack resource parameter to
 use the output value. For example:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template_a) do
   ...
   outputs.address do
@@ -110,9 +122,9 @@ SparkleFormation.new(:template_a) do
   end
   ...
 end
-```
+~~~
 
-```ruby
+~~~ruby
 SparkleFormation.new(:template_b) do
   ...
   parameters.address do
@@ -120,21 +132,21 @@ SparkleFormation.new(:template_b) do
   end
   ...
 end
-```
+~~~
 
-```ruby
+~~~ruby
 SparkleFormation.new(:root_template) do
   nest!(:template_a)
   nest!(:template_b)
 end
-```
+~~~
 
 When the final template file is compiled SparkleFormation will not
 bubble the `Address` parameter to the root stack. Because `template_b`
 defines an output the a matching name, SparkleFormation automatically
 uses that output value:
 
-```json
+~~~json
 ...
     "TemplateB": {
       "Type": "AWS::CloudFormation::Stack",
@@ -147,7 +159,7 @@ uses that output value:
             ]
           }
 ...
-```
+~~~
 
 Shallow nesting easily exposes the power of nesting stack resources
 while maintaining a single point of access for managing a stack. This
@@ -168,7 +180,7 @@ The method expects a block to be provided. This block handles storage
 of the nested stack template (if required) and any updates to the
 original stack resource.
 
-```ruby
+~~~ruby
 sfn = SparkleFormation.compile(template_path, :sparkle)
 
 sfn.apply_nesting(:shallow) do |stack_name, nested_stack_sfn, original_stack_resource|
@@ -177,7 +189,7 @@ sfn.apply_nesting(:shallow) do |stack_name, nested_stack_sfn, original_stack_res
   original_stack_resource.properites.delete!(:stack)
   original_stack_resource.properties.set!('TemplateURL', template_url)
 end
-```
+~~~
 
 ### Deep Nesting
 
@@ -229,7 +241,7 @@ are added to the stacks to "push" the value down.
 
 This example will illustrate the behavior seen when outputs are "bubbled":
 
-```ruby
+~~~ruby
 SparkleFormation.new(:networking) do
   ...
   outputs.subnet do
@@ -238,39 +250,39 @@ SparkleFormation.new(:networking) do
   end
   ...
 end
-```
+~~~
 
-```ruby
+~~~ruby
 SparkleFormation.new(:infrastructure) do
   ...
   nest!(:networking)
   ...
 end
-```
+~~~
 
-```ruby
+~~~ruby
 SparkleFormation.new(:applications) do
   ...
   nest!(:moneymaker)
   ...
 end
-```
+~~~
 
-```ruby
+~~~ruby
 SparkleFormation.new(:moneymaker) do
   parameters.subnet do
     type 'String'
   end
   ...
 end
-```
+~~~
 
-```ruby
+~~~ruby
 SparkleFormation.new(:root) do
   nest!(:infrastructure)
   nest!(:applications)
 end
-```
+~~~
 
 When the `root` stack is compiled, it will first process the `infrastructure`
 nesting, which will in turn process the `networking` nesting. After processing
@@ -285,7 +297,7 @@ be passed to the `application` stack resource:
 _NOTE: The below example includes the nested stack contents. A real template
 will simply include a URL endpoint for fetching the document._
 
-```json
+~~~json
 {
   "Resources": {
     "Infrastructure": {
@@ -369,7 +381,7 @@ will simply include a URL endpoint for fetching the document._
     }
   }
 }
-```
+~~~
 
 When the `root` template is compiled, it nests the `infrastructure` template, which in turn
 nests the `networking` template. The `Subnet` output is found, registered, and the compilation
@@ -401,7 +413,7 @@ The method expects a block to be provided. This block handles storage
 of the nested stack template (if required) and any updates to the
 original stack resource.
 
-```ruby
+~~~ruby
 sfn = SparkleFormation.compile(template_path, :sparkle)
 
 sfn.apply_nesting(:deep) do |stack_name, nested_stack_sfn, original_stack_resource|
@@ -410,4 +422,4 @@ sfn.apply_nesting(:deep) do |stack_name, nested_stack_sfn, original_stack_resour
   original_stack_resource.properites.delete!(:stack)
   original_stack_resource.properties.set!('TemplateURL', template_url)
 end
-```
+~~~

--- a/docs/sparkle-packs.md
+++ b/docs/sparkle-packs.md
@@ -1,3 +1,18 @@
+---
+title: "SparklePacks"
+category: "dsl"
+weight: 7
+anchors:
+  - title: "Cheatsheet"
+    url: "#cheatsheet-breakdown"
+  - title: "Requirements"
+    url: "#requirements"
+  - title: "Layout"
+    url: "#layout"
+  - title: "Usage"
+    url: "#usage"
+---
+
 ## SparklePacks
 
 SparklePacks are a way to package and ship SparkleFormation collections
@@ -37,14 +52,14 @@ and file naming are decoupled.
 A SparklePack is simply a directory containing a `sparkleformation`
 subdirectory which contains all distributed building blocks:
 
-```
+~~~
 > tree
 .
 |____sparkleformation
 | |____dynamics
 | |____components
 | |____registry
-```
+~~~
 
 ### Usage
 
@@ -53,14 +68,14 @@ SparklePack based on global configuration and current working directory.
 A customized pack can be provided on instantiation to override this
 behavior:
 
-```ruby
+~~~ruby
 root_pack = SparkleFormation::SparklePack.new(
   :root => PATH_TO_PACK
 )
 sfn = SparkleFormation.new(:my_template, :sparkle => root_pack) do
   # Define template
 end
-```
+~~~
 
 It is also possible to add additional SparklePacks to an existing
 SparkleFormation.
@@ -71,7 +86,7 @@ SparkleFormation.
 
 Building from the previous example, adding a additional pack:
 
-```ruby
+~~~ruby
 root_pack = SparkleFormation::SparklePack.new(
   :root => PATH_TO_PACK
 )
@@ -84,7 +99,7 @@ sfn = SparkleFormation.new(
   :sparkle => root_pack
 )
 sfn.sparkle.add_sparkle(custom_pack)
-```
+~~~
 
 With this `custom_pack` added to the collection, the SparkleFormation
 lookup for building blocks will follow the order:
@@ -95,7 +110,7 @@ lookup for building blocks will follow the order:
 By default new packs added will retain higher precedence than existing
 packs already added:
 
-```ruby
+~~~ruby
 root_pack = SparkleFormation::SparklePack.new(
   :root => PATH_TO_PACK
 )
@@ -112,7 +127,7 @@ sfn = SparkleFormation.new(
 )
 sfn.sparkle.add_sparkle(custom_pack)
 sfn.sparkle.add_sparkle(override_pack)
-```
+~~~
 
 
 In the above example `override_pack` holds the second highest precedence
@@ -126,7 +141,7 @@ following order:
 It is possible to force a pack to the lowest precedence level when
 adding:
 
-```ruby
+~~~ruby
 root_pack = SparkleFormation::SparklePack.new(
   :root => PATH_TO_PACK
 )
@@ -143,7 +158,7 @@ sfn = SparkleFormation.new(
 )
 sfn.sparkle.add_sparkle(custom_pack)
 sfn.sparkle.add_sparkle(base_pack, :low)
-```
+~~~
 
 This example demonstrates how to add a pack at the lowest precedence
 level allowing currently registered SparklePacks to retain their
@@ -163,7 +178,7 @@ SparklePacks are structured such that it is easy to package and
 distrbute them via RubyGems. An example file structure for `my-pack`
 gem:
 
-```
+~~~
 > tree
 .
 |____my-pack.gemspec
@@ -173,19 +188,19 @@ gem:
 | | |____components
 | | |____registry
 | |____my-pack.rb
-```
+~~~
 
 Then register the pack:
 
-```ruby
+~~~ruby
 # ./lib/my-pack.rb
 
 SparkleFormation::SparklePack.register!
-```
+~~~
 
 Once registered, packs can be loaded via name:
 
-```ruby
+~~~ruby
 require 'my-pack'
 root_pack = SparkleFormation::SparklePack.new(:name => 'my-pack')
 
@@ -193,4 +208,4 @@ sfn = SparkleFormation.new(
   :my_template,
   :sparkle => root_pack
 )
-```
+~~~

--- a/docs/sparkleformation-dsl.md
+++ b/docs/sparkleformation-dsl.md
@@ -1,3 +1,16 @@
+---
+title: "SparkleFormation DSL"
+category: "dsl"
+weight: 2
+anchors:
+  - title: "Behavior"
+    url: "#behavior"
+  - title: "Key Alteration"
+    url: "#key-alteration"
+  - title: "Data Access"
+    url: "#data-access"
+---
+
 ## SparkleFormation DSL
 
 The SparkleFormation DSL (domain specific language) is based
@@ -23,22 +36,22 @@ of key values.
 The default behavior of SparkleFormation is to camel case all Hash keys.
 This is done via:
 
-```ruby
+~~~ruby
 AttributeStruct.camel_keys = true
-```
+~~~
 
 And results in all Hash keys in the resultant compile Hash being converted
 to a camel cased format:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   parameters.creator.default 'spox'
 end
-```
+~~~
 
 The resultant data structure after compiling:
 
-```ruby
+~~~ruby
 {
   "Parameters": {
     "Creator": {
@@ -46,22 +59,22 @@ The resultant data structure after compiling:
     }
   }
 }
-```
+~~~
 
 In some cases it may be desired to have a key _not_
 be automatically camel cased. Camel casing can be
 disabled via a helper method that is attached to the
 Symbol and String instances:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   parameters.set!(:creator.disable_camel!).default 'spox'
 end
-```
+~~~
 
 The resultant data structure after compiling:
 
-```ruby
+~~~ruby
 {
   "Parameters": {
     "creator": {
@@ -69,7 +82,7 @@ The resultant data structure after compiling:
     }
   }
 }
-```
+~~~
 
 Depending on the formatting of the target template there
 may be lack of consistency within certain locations. A
@@ -87,7 +100,7 @@ When the camel casing is enabled on AttributeStruct, this is merely
 the default behavior and can be overridden, even from within
 the DSL. For example:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   parameters do
     camel_keys_set!(:auto_disable)
@@ -95,11 +108,11 @@ SparkleFormation.new(:test) do
   end
   outputs.creator.value ref!(:creator.disable_camel!)
 end
-```
+~~~
 
 The resultant data structure after compiling:
 
-```ruby
+~~~ruby
 {
   "Parameters": {
     "creator": {
@@ -112,7 +125,7 @@ The resultant data structure after compiling:
     }
   }
 }
-```
+~~~
 
 This example shows how the behavior of the Hash key modification
 can be altered at a specific context within the data structure.
@@ -120,7 +133,7 @@ New values added (as well as nested) will not the camel casing
 modification applied. The behavior can be adjusted at multiple
 depth locations, and that behavior will persist on re-entry:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   parameters do
     camel_keys_set!(:auto_disable)
@@ -133,11 +146,11 @@ SparkleFormation.new(:test) do
   parameters.creator.type 'String'
   parameters.author.default 'John Doe'
 end
-```
+~~~
 
 The resultant data structure after compiling:
 
-```ruby
+~~~ruby
 {
   "Parameters": {
     "creator": {
@@ -154,7 +167,8 @@ The resultant data structure after compiling:
     }
   }
 }
-```
+~~~
+
 ### Features
 
 #### Data Access
@@ -175,18 +189,18 @@ can be defined for the block. If provided, AttributeStruct will
 pass the local AttributeStruct instance to the block when it
 is executed:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   parameters.creator.default 'spox'
   parameters do |params|
     author.default params.creator.default
   end
 end
-```
+~~~
 
 The resultant data structure after compiling:
 
-```ruby
+~~~ruby
 {
   "Parameters": {
     "Creator": {
@@ -197,25 +211,25 @@ The resultant data structure after compiling:
     }
   }
 }
-```
+~~~
 
 ##### Parent Context Data
 
 It is possible to access the parent context data from the current
 context:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   parameters.creator.default 'spox'
   parameters.author do
     default parent!.creator.default
   end
 end
-```
+~~~
 
 The resultant data structure after compiling:
 
-```ruby
+~~~ruby
 {
   "Parameters": {
     "Creator": {
@@ -226,7 +240,7 @@ The resultant data structure after compiling:
     }
   }
 }
-```
+~~~
 
 
 ##### Root Context Data
@@ -234,16 +248,16 @@ The resultant data structure after compiling:
 It is possible to access the root context data from the current
 context:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   parameters.creator.default 'spox'
   parameters.author.default root!.parameters.creator.default
 end
-```
+~~~
 
 The resultant data structure after compiling:
 
-```ruby
+~~~ruby
 {
   "Parameters": {
     "Creator": {
@@ -254,25 +268,25 @@ The resultant data structure after compiling:
     }
   }
 }
-```
+~~~
 
 ##### Raw Access
 
 The raw Hash instance holding the data of the current context
 can be reached using the `data!` method:
 
-```ruby
+~~~ruby
 SparkleFormation.new(:test) do
   parameters.creator.default 'spox'
   if(data!['Creator'].default == 'spox')
     parameters.author.default 'xops'
   end
 end
-```
+~~~
 
 The resultant data structure after compiling:
 
-```ruby
+~~~ruby
 {
   "Parameters": {
     "Creator": {
@@ -283,6 +297,7 @@ The resultant data structure after compiling:
     }
   }
 }
-```
+~~~
+
 > NOTE: Because `data!` returns a Hash instance, no automatic formatting
 > (camel case conversions) will be applied to keys when accessing values.

--- a/docs/stack-policies.md
+++ b/docs/stack-policies.md
@@ -1,3 +1,14 @@
+---
+title: "Stack Policies"
+category: "dsl"
+weight: 8
+anchors:
+  - title: "Template Usage"
+    url: "#template-usage"
+  - title: "Library Usage"
+    url: "#library-usage"
+---
+
 ## Stack Policies
 
 AWS CloudFormation includes support for stack policies. These
@@ -15,7 +26,7 @@ Resource policies can be defined within a SparkleFormation
 template. This allows for policies to be programatically generated
 in the same manner as the stack template itself.
 
-```ruby
+~~~ruby
 template = SparkleFormation.new(:test) do
   resources.my_resource do
     policy do
@@ -24,7 +35,7 @@ template = SparkleFormation.new(:test) do
     end
   end
 end
-```
+~~~
 
 ### Library Usage
 
@@ -32,7 +43,7 @@ SparkleFormation can extract stack policies from a template after
 it has been compiled. Once extracted, the policy can be applied
 to the stack as dictated by the API.
 
-```ruby
+~~~ruby
 template = SparkleFormation.new(:test) do
   resources.my_resource do
     policy do
@@ -43,11 +54,11 @@ template = SparkleFormation.new(:test) do
 end
 
 policy = template.generate_policy
-```
+~~~
 
 This generates a policy data structure:
 
-```ruby
+~~~ruby
 {
   "Statement" => [
     {
@@ -76,4 +87,4 @@ This generates a policy data structure:
     }
   ]
 }
-```
+~~~

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -1,3 +1,14 @@
+---
+title: "Translation"
+category: "dsl"
+weight: 9
+anchors:
+  - title: "Supported Translations"
+    url: "#supported-translations"
+  - title: "Usage"
+    url: "#usage"
+---
+
 ## Translation
 
 SparkleFormation has alpha support for template translation from
@@ -20,7 +31,7 @@ the template must be compiled, then it is passed to the translator
 which converts the CFN specific template to the expected format
 of the target API:
 
-```ruby
+~~~ruby
 sfn = SparkleFormation.new(:my_stack) do
   ...
 end
@@ -29,7 +40,7 @@ cfn_template = sfn.compile.dump!
 translator = SparkleFormation::Translation::Heat.new(cfn_template)
 
 heat_template = translator.translate!
-```
+~~~
 
 In general applications of translators, the implementation will
 first collect optional template parameters prior to translation
@@ -37,7 +48,7 @@ allowing the translator access to parameters that may be required
 in places where the resultant template may not have support for
 dynamic references. These can then be passed to the translator:
 
-```ruby
+~~~ruby
 sfn = SparkleFormation.new(:my_stack) do
   ...
 end
@@ -50,4 +61,4 @@ translator = SparkleFormation::Translation::Heat.new(
 )
 
 heat_template = translator.translate!
-```
+~~~


### PR DESCRIPTION
Changes primarily consist of the following: 

- Add Yaml "frontmatter" to documentation pages w/ page metadata and navigation helper content
- Change from triple backticks (```) to triple tilde characters (`~`) for fenced code blocks (for Kramdown)
- Remove `.md` extensions from links
