### PR TITLE
Error on name collisions within pack

### DIFF
--- a/test/specs/packs/name_collision_pack/components/base.rb
+++ b/test/specs/packs/name_collision_pack/components/base.rb
@@ -1,0 +1,3 @@
+SparkleFormation.component(:base) do
+  testing true
+end

--- a/test/specs/packs/name_collision_pack/dynamics/base.rb
+++ b/test/specs/packs/name_collision_pack/dynamics/base.rb
@@ -1,0 +1,3 @@
+SparkleFormation.dynamic(:base) do |n, c={}|
+  testing true
+end

--- a/test/specs/packs/name_collision_pack/registry/base.rb
+++ b/test/specs/packs/name_collision_pack/registry/base.rb
@@ -1,0 +1,3 @@
+SfnRegistry.register(:base) do |*_|
+  testing true
+end

--- a/test/specs/packs/name_collision_pack/stack.rb
+++ b/test/specs/packs/name_collision_pack/stack.rb
@@ -1,0 +1,3 @@
+SparkleFormation.new(:stack) do
+  testing true
+end

--- a/test/specs/packs/name_collision_pack/stack_dup.rb
+++ b/test/specs/packs/name_collision_pack/stack_dup.rb
@@ -1,0 +1,3 @@
+SparkleFormation.new(:stack) do
+  testing true
+end

--- a/test/specs/packs/name_collision_pack_item/components/base.rb
+++ b/test/specs/packs/name_collision_pack_item/components/base.rb
@@ -1,0 +1,3 @@
+SparkleFormation.component(:base) do
+  testing true
+end

--- a/test/specs/packs/name_collision_pack_item/dynamics/base.rb
+++ b/test/specs/packs/name_collision_pack_item/dynamics/base.rb
@@ -1,0 +1,3 @@
+SparkleFormation.dynamic(:base) do |n, c={}|
+  testing true
+end

--- a/test/specs/packs/name_collision_pack_item/dynamics/base_dup.rb
+++ b/test/specs/packs/name_collision_pack_item/dynamics/base_dup.rb
@@ -1,0 +1,3 @@
+SparkleFormation.dynamic(:base) do |n, c={}|
+  testing true
+end

--- a/test/specs/packs/name_collision_pack_item/registry/base.rb
+++ b/test/specs/packs/name_collision_pack_item/registry/base.rb
@@ -1,0 +1,3 @@
+SfnRegistry.register(:base) do |*_|
+  testing true
+end

--- a/test/specs/packs/name_collision_pack_item/stack.rb
+++ b/test/specs/packs/name_collision_pack_item/stack.rb
@@ -1,0 +1,3 @@
+SparkleFormation.new(:stack) do
+  testing true
+end

--- a/test/specs/packs/valid_pack/components/base.rb
+++ b/test/specs/packs/valid_pack/components/base.rb
@@ -1,0 +1,3 @@
+SparkleFormation.component(:base) do
+  testing true
+end

--- a/test/specs/packs/valid_pack/dynamics/base.rb
+++ b/test/specs/packs/valid_pack/dynamics/base.rb
@@ -1,0 +1,3 @@
+SparkleFormation.dynamic(:base) do |n, c={}|
+  testing true
+end

--- a/test/specs/packs/valid_pack/registry/base.rb
+++ b/test/specs/packs/valid_pack/registry/base.rb
@@ -1,0 +1,3 @@
+SfnRegistry.register(:base) do |*_|
+  :fubar
+end

--- a/test/specs/packs/valid_pack/stack.rb
+++ b/test/specs/packs/valid_pack/stack.rb
@@ -1,0 +1,3 @@
+SparkleFormation.new(:stack) do
+  testing true
+end

--- a/test/specs/sparkle_spec.rb
+++ b/test/specs/sparkle_spec.rb
@@ -1,0 +1,49 @@
+describe SparkleFormation::Sparkle do
+
+  describe 'valid sparkle pack' do
+
+    before do
+      @pack = SparkleFormation::Sparkle.new(
+        :root => File.join(File.dirname(__FILE__), 'packs/valid_pack')
+      )
+    end
+
+    it 'should have template registered' do
+      @pack.get(:template, :stack).must_be_kind_of Hash
+    end
+
+    it 'should have a dynamic registered' do
+      @pack.get(:dynamic, :base).must_be_kind_of Hash
+    end
+
+    it 'should have a component registered' do
+      @pack.get(:component, :base).must_be_kind_of Hash
+    end
+
+    it 'should have a registry item registered' do
+      @pack.get(:registry, :base).must_be_kind_of Hash
+    end
+
+  end
+
+  describe 'invalid name collision pack' do
+
+    it 'should raise a KeyError on duplicate template name' do
+      ->{
+        SparkleFormation::Sparkle.new(
+          :root => File.join(File.dirname(__FILE__), 'packs/name_collision_pack')
+        ).templates
+      }.must_raise KeyError
+    end
+
+    it 'should raise a KeyError on duplicate dynamic name' do
+      ->{
+        SparkleFormation::Sparkle.new(
+          :root => File.join(File.dirname(__FILE__), 'packs/name_collision_pack_item')
+        )
+      }.must_raise KeyError
+    end
+
+  end
+
+end


### PR DESCRIPTION
Resolves issue described in #95 where re-used names will silently
overwrite previously registered item. This will force an error state
which must be resolved before continuation.