### PR TITLE
make specs behave like any other ruby library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,18 @@ Please base all pull requests off the `develop` branch. Merges to
 `master` only occur through the `develop` branch. Pull requests
 based on `master` will likely be cherry picked.
 
+## Tests
+
+Add a test to your changes.
+Tests can be run with bundler:
+
+```
+bundle
+bundle exec rake
+bundle exec ruby test/specs/attribute_spec.rb
+bundle exec ruby test/specs/attribute_spec.rb -n '/should generate Fn::Join with custom delimiter/'
+```
+
 ## Issues
 
 Need to report an issue? Use the github issues:

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require "bundler/setup"
+require "rake/testtask"
+
+Rake::TestTask.new do |test|
+  test.pattern = 'test/**/*_spec.rb'
+  test.verbose = true
+end
+
+task :default => :test

--- a/sparkle_formation.gemspec
+++ b/sparkle_formation.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json'
   s.add_dependency 'bogo'
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'rake'
   s.executables << 'generate_sparkle_docs'
   s.files = Dir['{lib,docs}/**/*'] + %w(sparkle_formation.gemspec README.md CHANGELOG.md LICENSE)
 end

--- a/test/spec.rb
+++ b/test/spec.rb
@@ -1,17 +1,6 @@
 require 'sparkle_formation'
 require 'minitest/autorun'
 
-Dir.glob(
-  File.join(
-    File.expand_path(
-      File.dirname(__FILE__)
-    ),
-    'specs/**/**/*_spec.rb'
-  )
-).each do |path|
-  require path
-end
-
 SparkleFormation.sparkle_path = File.join(
   File.dirname(__FILE__), 'specs', 'sparkleformation'
 )

--- a/test/specs/attribute_spec.rb
+++ b/test/specs/attribute_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../spec'
+
 describe SparkleFormation::SparkleAttribute do
 
   before do

--- a/test/specs/basic_spec.rb
+++ b/test/specs/basic_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../spec'
+
 describe SparkleFormation do
 
   before do

--- a/test/specs/sparkle_spec.rb
+++ b/test/specs/sparkle_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../spec'
+
 describe SparkleFormation::Sparkle do
 
   describe 'valid sparkle pack' do

--- a/test/specs/template_spec.rb
+++ b/test/specs/template_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../spec'
+
 describe SparkleFormation do
 
   before do

--- a/test/specs/translations/heat/ec2_subnet_spec.rb
+++ b/test/specs/translations/heat/ec2_subnet_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../../../spec'
+
 describe SparkleFormation::Translation::Heat do
   describe 'EC2::Subnet' do
 

--- a/test/specs/translations/heat/ec2_vpc_spec.rb
+++ b/test/specs/translations/heat/ec2_vpc_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../../../spec'
+
 describe SparkleFormation::Translation::Heat do
   describe 'EC2::VPC' do
 

--- a/test/specs/translations/heat/elasticloadbalancing_load_balancer_spec.rb
+++ b/test/specs/translations/heat/elasticloadbalancing_load_balancer_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../../../spec'
+
 describe SparkleFormation::Translation::Heat do
   describe 'ElasticLoadbalancing::LoadBalancer' do
 


### PR DESCRIPTION
@chrisroberts 

now these work:

```
rake
rake test
```

and this also works 

```
ruby ruby test/specs/attribute_spec.rb
ruby ruby test/specs/attribute_spec.rb -n '/should generate Fn::Join with custom delimiter/'
```