### PR TITLE
make debugging easy

### DIFF
--- a/lib/sparkle_formation/sparkle_struct.rb
+++ b/lib/sparkle_formation/sparkle_struct.rb
@@ -61,5 +61,15 @@ class SparkleFormation
     end
     alias_method :state!, :_state
 
+    # Override so people can print something instead of creating an attribute called puts
+    def puts(*args)
+      $stdout.puts(*args)
+    end
+
+    # Override so people can raise something instead of creating an attribute called raise
+    def raise(*args)
+      ::Kernel.raise(*args)
+    end
+
   end
 end

--- a/test/specs/basic_spec.rb
+++ b/test/specs/basic_spec.rb
@@ -1,5 +1,13 @@
 describe SparkleFormation do
 
+  def capture_stdout
+    old, $stdout = $stdout, StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = old
+  end
+
   before do
     SparkleFormation.sparkle_path = File.join(File.dirname(__FILE__), 'sparkleformation')
   end
@@ -90,6 +98,26 @@ describe SparkleFormation do
     it 'should properly traverse ancestors' do
       full_stack = MultiJson.load(File.read(File.join(File.dirname(__FILE__), 'results', 'traversal.json')))
       SparkleFormation.compile(:traversal).must_equal full_stack
+    end
+
+    it 'should call puts' do
+      output = capture_stdout do
+        SparkleFormation.new(:dummy) do
+          puts 111
+          test 111
+        end.dump.must_equal 'Test' => 111
+      end
+      output.must_equal "111\n"
+    end
+
+    it 'should call raise' do
+      e = assert_raises RuntimeError do
+        SparkleFormation.new(:dummy) do
+          raise "111"
+          test 111
+        end.dump
+      end
+      e.message.must_equal "111"
     end
 
   end


### PR DESCRIPTION
atm calling puts / raise creates and attribute ... so there is no easy way to debug things, especially not for people that are new to ruby ... so make it easy / straight forward by defining at least puts and raise

@chrisroberts

... ideally get rid of this whole method missing foobar and only allow predefined methods + attribute :xyz, 123 for one-offs as sinatra / capistrano etc frameworks do ... overriding everything looks nice but is super hard to debug once something goes wrong ...

(reopened #106 against develop)