### PR TITLE
a typo often ends up creating structs that then make other names brea…

### DIFF
--- a/lib/sparkle_formation/sparkle_attribute.rb
+++ b/lib/sparkle_formation/sparkle_attribute.rb
@@ -325,7 +325,12 @@ class SparkleFormation
     # @param args [Object] argument list for dynamic
     # @return [self]
     def dynamic!(name, *args, &block)
-      SparkleFormation.insert(name, self, *args, &block)
+      if args.inspect.include?('#<Sparkle')
+        caller = ::Kernel.caller.first.sub(Dir.pwd, '.')
+        Kernel.raise NameError, "Using struct as argument, use a name at #{caller}"
+      else
+        SparkleFormation.insert(name, self, *args, &block)
+      end
     end
 
     # Registry insertion helper method

--- a/test/specs/basic_spec.rb
+++ b/test/specs/basic_spec.rb
@@ -122,6 +122,17 @@ describe SparkleFormation do
       e.message.must_equal "111"
     end
 
+    it 'should raise a clear error when hitting method_missing by accident' do
+      e = assert_raises NameError do
+        SparkleFormation.new(:dummy) do
+          dynamic! :ec2_instance, oooppps do
+            test 111
+          end
+        end.dump
+      end
+      e.message.must_equal "Using struct as argument. Use a name! ./test/specs/basic_spec.rb:#{__LINE__ - 5}:in `block (5 levels) in <main>'"
+    end
+
   end
 
 end


### PR DESCRIPTION
…k ... adding a sanity check to make these errors easier to spot

@chrisroberts 