### PR TITLE
end users do not need to generate docs

### DIFF
--- a/sparkle_formation.gemspec
+++ b/sparkle_formation.gemspec
@@ -15,6 +15,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'bogo'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rake'
-  s.executables << 'generate_sparkle_docs'
   s.files = Dir['{lib,docs}/**/*'] + %w(sparkle_formation.gemspec README.md CHANGELOG.md LICENSE)
 end


### PR DESCRIPTION
@chrisroberts 

if anyone other internal tool is using this, they can get the bin directory from the gem or call some internal api