### PR TITLE
Always set instance origin when creating new struct

### DIFF
--- a/lib/sparkle_formation/sparkle_struct.rb
+++ b/lib/sparkle_formation/sparkle_struct.rb
@@ -44,6 +44,15 @@ class SparkleFormation
       ::SparkleFormation::SparkleStruct
     end
 
+    # Instantiation override properly set origin template
+    #
+    # @return [SparkleStruct]
+    def _klass_new(*args, &block)
+      inst = super
+      inst._set_self(_self)
+      inst
+    end
+
     # Override the state to force helpful error when no value has been
     # provided
     #

--- a/test/specs/sparkleformation/components/registry_component.rb
+++ b/test/specs/sparkleformation/components/registry_component.rb
@@ -1,0 +1,6 @@
+SparkleFormation.component(:registry_component) do
+  nested do
+    entry_one registry!(:item)
+    entry_two registry!(:item)
+  end
+end

--- a/test/specs/sparkleformation/registry/item.rb
+++ b/test/specs/sparkleformation/registry/item.rb
@@ -1,0 +1,3 @@
+SfnRegistry.register(:item) do
+  'item value'
+end

--- a/test/specs/sparkleformation/registry_in_component.rb
+++ b/test/specs/sparkleformation/registry_in_component.rb
@@ -1,0 +1,3 @@
+SparkleFormation.new(:registry_in_component).load(:registry_component).overrides do
+  complete true
+end

--- a/test/specs/template_spec.rb
+++ b/test/specs/template_spec.rb
@@ -36,4 +36,13 @@ describe SparkleFormation do
 
   end
 
+  describe 'Component registry usage' do
+
+    it 'should properly handle multiple registry requests' do
+      result = SparkleFormation.compile('registry_in_component.rb')
+      result['Complete'].must_equal true
+    end
+
+  end
+
 end


### PR DESCRIPTION
Addressing an issue raised in IRC:

> ... I get an error "Creator did not provide return reference! (ArgumentError)"

This ensures newly created structs will always have origin _self set.