### PR TITLE
warn when using ambiguous keys

### DIFF
--- a/lib/sparkle_formation/aws.rb
+++ b/lib/sparkle_formation/aws.rb
@@ -67,6 +67,11 @@ class SparkleFormation
       # @return [String, NilClass]
       def registry_key(key)
         key = key.to_s.tr('_', '')
+
+        if AWS_RESOURCES_AMBIGUOUS.include?(key)
+          warn "#{key} is ambiguous, please use a longer from"
+        end
+
         @@registry.keys.detect do |ref|
           ref = ref.downcase
           snake_parts = ref.split('::')

--- a/lib/sparkle_formation/aws/cfn_resources.rb
+++ b/lib/sparkle_formation/aws/cfn_resources.rb
@@ -4607,3 +4607,5 @@ AWS_RESOURCES = {"AWS::OpsWorks::App"=>
        :update_causes=>:unavailable}},
    :path=>"aws-properties-elasticache-security-group-ingress.html"},
  "AWS::SDB::Domain"=>{:properties=>[], :path=>"aws-properties-simpledb.html"}}
+
+AWS_RESOURCES_AMBIGUOUS = Set.new(AWS_RESOURCES.keys.group_by{|k| k.split('::').last }.select{|k,v| v.size > 1 }.keys.map(&:downcase))

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -194,7 +194,6 @@ class SparkleFormation
     # @param args [Object] parameters for dynamic
     # @return [SparkleStruct]
     def registry(registry_name, struct, *args)
-      result = false
       reg = struct._self.sparkle.get(:registry, registry_name)
       struct.instance_exec(*args, &reg[:block])
     end

--- a/test/specs/basic_spec.rb
+++ b/test/specs/basic_spec.rb
@@ -10,6 +10,14 @@ describe SparkleFormation do
     $stdout = old
   end
 
+  def capture_stderr
+    old, $stderr = $stderr, StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = old
+  end
+
   before do
     SparkleFormation.sparkle_path = File.join(File.dirname(__FILE__), 'sparkleformation')
   end
@@ -120,6 +128,15 @@ describe SparkleFormation do
         end.dump
       end
       e.message.must_equal "111"
+    end
+
+    it 'warns when using ambiguous types' do
+      err = capture_stderr do
+        SparkleFormation.new(:dummy) do
+          dynamic!(:instance, 'xxxx')
+        end.dump
+      end
+      err.must_include "instance is ambiguous, please use a longer from"
     end
 
   end


### PR DESCRIPTION
@chrisroberts 

after learning how these lookups worked I noticed that we used a few ambiguous ones and got what we wanted by accident ... but would be nice to warn folks :)