### PR TITLE
Tag a resource with a hash instead of repetetive key value pairs

### DIFF
--- a/lib/sparkle_formation/sparkle_attribute.rb
+++ b/lib/sparkle_formation/sparkle_attribute.rb
@@ -314,6 +314,15 @@ class SparkleFormation
       end
     end
 
+    # Tag a resource with a hash instead of repetetive key value pairs
+    def _tags(hash)
+      tags hash.map { |k, v|
+        key = k.is_a?(Symbol) ? _process_key(k, :force) : k
+        {'Key' => key, 'Value' => v}
+      }
+    end
+    alias_method :tags!, :_tags
+
     # @return [TrueClass, FalseClass]
     def rhel?
       !!@platform[:rhel]

--- a/test/specs/basic_spec.rb
+++ b/test/specs/basic_spec.rb
@@ -122,6 +122,12 @@ describe SparkleFormation do
       e.message.must_equal "111"
     end
 
+    it 'should tag with a hash' do
+      SparkleFormation.new(:dummy) do
+        tags! foo: "Bar"
+      end.dump.must_equal({"Tags" => [{"Key" => "Foo", "Value" => "Bar"}]})
+    end
+
   end
 
 end


### PR DESCRIPTION
@chrisroberts 
we are adding a lot of tags to our resources and created this helper to make it easier to read and write ... hope you like it :)


```Ruby
tags [
  {"Key" => "Foo", "Value" => "Bar"}
]
# can now be written as
tags! foo: "Bar"
```