### PR TITLE
make created dynamics adressable / reusable without guessing

### DIFF
--- a/lib/sparkle_formation/sparkle_attribute.rb
+++ b/lib/sparkle_formation/sparkle_attribute.rb
@@ -361,5 +361,15 @@ class SparkleFormation
       SparkleFormation.nest(template, self, *args, &block)
     end
 
+    # store or retrieve the name of this resource
+    def _resource_name(name=nil)
+      if name
+        @resource_name = name
+      else
+        @resource_name
+      end
+    end
+    alias_method :resource_name!, :_resource_name
+
   end
 end

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -278,6 +278,7 @@ class SparkleFormation
         struct.resources.set!(resource_name)
         new_resource = struct.resources[resource_name]
         new_resource.type lookup_key
+        new_resource.resource_name! resource_name
         properties = new_resource.properties
         config_keys = _config.keys.zip(_config.keys.map{|k| snake(k).to_s.tr('_', '')})
         SfnAws.resource(dynamic_name, :properties).each do |prop_name|


### PR DESCRIPTION
atm there are 2 way of using created things:

memorize how names are constructed and build them by hand -> not dry / error prone

```Ruby
dynamic!(:ec2_instance, :foo_bar) {  }
dynamic!(:record_set, :bar_foo).properties do
  resource_records [attr!(:foo_bar_ec2_instance, :private_ip)]
end
```

construct them with ugly splat hacks

```Ruby
instance = [:ec2_instance, :foo_bar]
dynamic!(*instance) {  }
dynamic!(:record_set, :bar_foo).properties do
  resource_records [attr!(instance.reverse.join('_').to_sym, :private_ip)]
end
```

this PR introduces a new, dry way of doing things:

```Ruby
instance = dynamic!(:ec2_instance, :foo_bar) {  }.resource_name!
dynamic!(:record_set, :bar_foo).properties do
  resource_records [attr!(instance, :private_ip)]
end
```

@chrisroberts 