### PR TITLE
Add helper method to provide local resource name

### DIFF
--- a/lib/sparkle_formation/sparkle_attribute.rb
+++ b/lib/sparkle_formation/sparkle_attribute.rb
@@ -7,6 +7,28 @@ class SparkleFormation
 
     autoload :Aws, 'sparkle_formation/sparkle_attribute/aws'
 
+    # Return current resource name
+    #
+    # @return [String]
+    def _resource_name
+      result = nil
+      if(_parent)
+        if(_parent._parent == _root)
+          result = _parent._data.detect do |r_name, r_value|
+            r_value == self
+          end
+          result = result.first if result
+        else
+          result = _parent._resource_name
+        end
+      end
+      unless(result)
+        ::Kernel.raise NameError.new 'Failed to determine current resource name! (Check call location)'
+      end
+      result
+    end
+    alias_method :resource_name!, :_resource_name
+
     # Execute system command
     #
     # @param command [String]

--- a/sparkle_formation.gemspec
+++ b/sparkle_formation.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = 'Ruby DSL for programmatic orchestration API template generation'
   s.license = 'Apache-2.0'
   s.require_path = 'lib'
-  s.add_dependency 'attribute_struct', '>= 0.2.23', '< 0.4'
+  s.add_dependency 'attribute_struct', '>= 0.2.27', '< 0.4'
   s.add_dependency 'multi_json'
   s.add_dependency 'bogo'
   s.add_development_dependency 'minitest'

--- a/test/specs/attribute_spec.rb
+++ b/test/specs/attribute_spec.rb
@@ -147,4 +147,21 @@ describe SparkleFormation::SparkleAttribute do
     @attr.no_value!.must_equal 'Ref' => 'AWS::NoValue'
   end
 
+  it 'should provide resource name for resource block' do
+    result = @sfn.overrides do
+      resources.my_custom_resource do
+        properties do
+          resource_name resource_name!
+          nested do
+            resource_name resource_name!
+          end
+        end
+        my_name resource_name!
+      end
+    end.dump
+    result['Resources']['MyCustomResource']['MyName'].must_equal 'MyCustomResource'
+    result['Resources']['MyCustomResource']['Properties']['ResourceName'].must_equal 'MyCustomResource'
+    result['Resources']['MyCustomResource']['Properties']['Nested']['ResourceName'].must_equal 'MyCustomResource'
+  end
+
 end


### PR DESCRIPTION
Prompted by #126. Extracted implementation that has been used previously
directly within templates to provide resource name (though not limited
to just resource usage) based on current context.

_NOTE: Requires AttributeStruct release for internal data storage timing
fix_