### PR TITLE
Generate error on resource lookup if multiple matches

### DIFF
--- a/lib/sparkle_formation/resources.rb
+++ b/lib/sparkle_formation/resources.rb
@@ -66,8 +66,10 @@ class SparkleFormation
       # @param key [String, Symbol]
       # @return [String, NilClass]
       def registry_key(key)
+        o_key = key
         key = key.to_s.tr('_', '')
-        @@registry.keys.detect do |ref|
+        snake_parts = nil
+        result = @@registry.keys.detect do |ref|
           ref = ref.downcase
           snake_parts = ref.split('::')
           until(snake_parts.empty?)
@@ -76,6 +78,18 @@ class SparkleFormation
           end
           !snake_parts.empty?
         end
+        if(result)
+          collisions = @@registry.keys.find_all do |ref|
+            split_ref = ref.downcase.split('::')
+            ref = split_ref.slice(split_ref.size - snake_parts.size, split_ref.size).join('')
+            key == ref
+          end
+          if(collisions.size > 1)
+            raise ArgumentError.new 'Ambiguous dynamic name returned multiple matches! ' \
+              "`#{o_key.inspect}` -> #{collisions.sort.join(', ')}"
+          end
+        end
+        result
       end
 
       # Registry information for given type

--- a/test/specs/sparkle_formation_spec.rb
+++ b/test/specs/sparkle_formation_spec.rb
@@ -4,12 +4,12 @@ describe SparkleFormation do
 
   describe 'Class Methods' do
 
-    describe 'Type checks' do
+    before do
+      @template = SparkleFormation.new(:template)
+      @struct = @template.compile
+    end
 
-      before do
-        @template = SparkleFormation.new(:template)
-        @struct = @template.compile
-      end
+    describe 'Type checks' do
 
       it 'should require string-ish type for registry name' do
         ->{ SparkleFormation.registry(:thing, @struct) }.must_raise KeyError
@@ -32,6 +32,16 @@ describe SparkleFormation do
       end
 
     end
+
+    describe 'Builtin resource dynamics' do
+
+      it 'should raise error on ambiguous names' do
+        ->{ SparkleFormation.insert(:security_group, @struct, :test) }.must_raise ArgumentError
+        SparkleFormation.insert(:ec2_security_group, @struct, :test).wont_be_nil
+      end
+
+    end
+
   end
 
 end


### PR DESCRIPTION
Based off #120. Forces error state if multiple results are available.