### PR TITLE
Enforce helper method convention within DSL

### DIFF
--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -569,6 +569,9 @@ class SparkleFormation
         const = SparkleAttribute.const_get(camel(provider))
         struct_class = Class.new(SparkleStruct)
         struct_class.include(const)
+        struct_name = [SparkleStruct.name, camel(provider)].join('::')
+        struct_class.define_singleton_method(:name){ struct_name }
+        struct_class.define_singleton_method(:to_s){ struct_name }
       else
         struct_class = SparkleStruct
       end

--- a/lib/sparkle_formation/sparkle_struct.rb
+++ b/lib/sparkle_formation/sparkle_struct.rb
@@ -75,6 +75,9 @@ class SparkleFormation
     # Override to inspect result value and fetch root if value is a
     # FunctionStruct
     def method_missing(sym, *args, &block)
+      if(sym.to_s.start_with?('_') || sym.to_s.end_with?('!'))
+        ::Kernel.raise ::NoMethodError.new "Undefined method `#{sym}` for #{_klass.name}"
+      end
       result = super(*[sym, *args], &block)
       @table[_process_key(sym)] = function_bubbler(result)
     end

--- a/test/specs/basic_spec.rb
+++ b/test/specs/basic_spec.rb
@@ -152,6 +152,22 @@ describe SparkleFormation do
       end.dump
     end
 
+    it 'should error on unknown helper underscore prefix method' do
+      ->{
+        SparkleFormation.new(:dummy) do
+          value _dummy
+        end.dump
+      }.must_raise NoMethodError
+    end
+
+    it 'should error on unknown helper bang suffix method' do
+      ->{
+        SparkleFormation.new(:dummy) do
+          value dummy!
+        end.dump
+      }.must_raise NoMethodError
+    end
+
   end
 
 end


### PR DESCRIPTION
Disallow any usage of underscore prefix or bang suffix keys within
data structure. Enforces convention that these are always helper methods.