### PR TITLE
Define uniqueness based on name/provider combination

### DIFF
--- a/lib/sparkle_formation/sparkle.rb
+++ b/lib/sparkle_formation/sparkle.rb
@@ -5,6 +5,123 @@ class SparkleFormation
   # Independent collection of SparkleFormation items
   class Sparkle
 
+    # Evaluation context wrapper for loading SparkleFormation files
+    class EvalWrapper < BasicObject
+
+      # @!visibility private
+      def require(*args)
+        ::Kernel.require(*args)
+      end
+
+      # @!visibility private
+      class SparkleFormation
+
+        attr_accessor :sparkle_path
+
+        class << self
+
+          def insert(*args, &block)
+            ::SparkleFormation.insert(*args, &block)
+          end
+
+          def part_data(data=nil)
+            if(data)
+              @data = data
+            else
+              @data
+            end
+          end
+
+          def dynamic(name, args={}, &block)
+            part_data[:dynamic].push(
+              ::Smash.new(
+                :name => name,
+                :block => block,
+                :args => ::Smash[
+                  args.map(&:to_a)
+                ],
+                :type => :dynamic
+              )
+            ).last
+          end
+
+          def build(&block)
+            part_data[:component].push(
+              ::Smash.new(
+                :block => block,
+                :type => :component
+              )
+            ).last
+          end
+
+          def component(name, args={}, &block)
+            part_data[:component].push(
+              ::Smash.new(
+                :name => name,
+                :block => block,
+                :args => ::Smash[
+                  args.map(&:to_a)
+                ],
+                :type => :component
+              )
+            ).last
+          end
+
+          def dynamic_info(*args)
+            ::Smash.new(:metadata => {}, :args => {})
+          end
+
+        end
+
+        def initialize(*args)
+          opts = args.detect{|a| a.is_a?(Hash)} || {}
+          SparkleFormation.part_data[:template].push(
+            ::Smash.new(
+              :name => args.first,
+              :args => opts
+            )
+          )
+          raise ::TypeError
+        end
+
+        # @!visibility private
+        class Registry
+
+          def self.register(name, args={}, &block)
+            SparkleFormation.part_data[:registry].push(
+              ::Smash.new(
+                :name => name,
+                :block => block,
+                :args => ::Smash[
+                  args.map(&:to_a)
+                ],
+                :type => :registry
+              )
+            ).last
+          end
+
+        end
+      end
+
+      # @!visibility private
+      SfnRegistry = SparkleFormation::Registry
+
+      # NOTE: Enable access to top level constants but do not
+      # include deprecated constants to prevent warning outputs
+      ::Object.constants.each do |const|
+        unless(self.const_defined?(const)) # rubocop:disable Style/RedundantSelf
+          next if const == :Config || const == :TimeoutError
+          self.const_set(const, ::Object.const_get(const)) # rubocop:disable Style/RedundantSelf
+        end
+      end
+
+      # @!visibility private
+      def part_data(arg)
+        SparkleFormation.part_data(arg)
+      end
+
+    end
+
     class << self
 
       @@_pack_registry = Smash.new
@@ -61,113 +178,9 @@ class SparkleFormation
     end
 
     # Wrapper for evaluating sfn files to store within sparkle
-    # container and remove global application
-    # rubocop:disable Metrics/MethodLength
+    # container
     def eval_wrapper
-      klass = Class.new(BasicObject)
-      klass.class_eval(<<-EOS
-        def require(*args)
-          ::Kernel.require *args
-        end
-
-        class SparkleFormation
-
-          attr_accessor :sparkle_path
-
-          class << self
-
-            def insert(*args, &block)
-              ::SparkleFormation.insert(*args, &block)
-            end
-
-            def part_data(data=nil)
-              if(data)
-                @data = data
-              else
-                @data
-              end
-            end
-
-            def dynamic(name, args={}, &block)
-              part_data[:dynamic].push(
-                ::Smash.new(
-                  :name => name,
-                  :block => block,
-                  :args => Smash[
-                    args.map(&:to_a)
-                  ],
-                  :type => :dynamic
-                )
-              ).last
-            end
-
-            def build(&block)
-              part_data[:component].push(
-                ::Smash.new(
-                  :block => block,
-                  :type => :component
-                )
-              ).last
-            end
-
-            def component(name, args={}, &block)
-              part_data[:component].push(
-                ::Smash.new(
-                  :name => name,
-                  :block => block,
-                  :args => Smash[
-                    args.map(&:to_a)
-                  ],
-                  :type => :component
-                )
-              ).last
-            end
-
-            def dynamic_info(*args)
-              Smash.new(:metadata => {}, :args => {})
-            end
-
-          end
-
-          def initialize(*args)
-            SparkleFormation.part_data[:template].push(
-              ::Smash.new(
-                :name => args.first
-              )
-            )
-            raise TypeError
-          end
-
-          class Registry
-
-            def self.register(name, &block)
-              SparkleFormation.part_data[:registry].push(
-                ::Smash.new(
-                  :name => name,
-                  :block => block,
-                  :type => :registry
-                )
-              ).last
-            end
-
-          end
-        end
-
-        SfnRegistry = SparkleFormation::Registry
-
-        ::Object.constants.each do |const|
-          unless(self.const_defined?(const))
-            next if const == :Config || const == :TimeoutError # prevent warning output
-            self.const_set(const, ::Object.const_get(const))
-          end
-        end
-
-        def part_data(arg)
-          SparkleFormation.part_data(arg)
-        end
-        EOS
-      )
-      klass
+      Class.new(EvalWrapper)
     end
 
     include Bogo::Memoization
@@ -200,12 +213,15 @@ class SparkleFormation
     attr_reader :root
     # @return [Smash] raw part data
     attr_reader :raw_data
+    # @return [Symbol] provider
+    attr_accessor :provider
 
     # Create new sparkle instance
     #
     # @param args [Hash]
     # @option args [String] :root path to sparkle directories
     # @option args [String, Symbol] :name registered pack name
+    # @option args [String, Symbol] :provider name of default provider
     # @return [self]
     def initialize(args={})
       if(args[:name])
@@ -222,6 +238,7 @@ class SparkleFormation
         :registry => [],
         :template => []
       )
+      @provider = Bogo::Utility.snake(args.fetch(:provider, 'aws').to_s).to_sym
       @wrapper = eval_wrapper.new
       wrapper.part_data(raw_data)
       load_parts! unless @root == :none
@@ -259,16 +276,20 @@ class SparkleFormation
     #
     # @param type [String, Symbol] item type (see: TYPES)
     # @param name [String, Symbol] name of item
+    # @param target_provider [String, Symbol] restrict to provider
     # @return [Smash] requested item
     # @raises [NameError, Error::NotFound]
-    def get(type, name)
+    def get(type, name, target_provider=nil)
       unless(TYPES.keys.include?(type.to_s))
         raise NameError.new "Invalid type requested (#{type})! Valid types: #{TYPES.keys.join(', ')}"
       end
-      result = send(TYPES[type])[name]
+      unless(target_provider)
+        target_provider = provider
+      end
+      result = send(TYPES[type]).get(target_provider, name)
       if(result.nil? && TYPES[type] == 'templates')
         result = (
-          send(TYPES[type]).detect{|_, v|
+          send(TYPES[type]).fetch(target_provider, Smash.new).detect{|_, v|
             name = name.to_s
             short_name = v[:path].sub(%r{#{Regexp.escape(root)}/?}, '')
             v[:path] == name ||
@@ -323,13 +344,16 @@ class SparkleFormation
             unless(data[:name])
               data[:name] = slim_path.tr('/', '__').sub(/\.(rb|json)$/, '')
             end
-            if(templates[data[:name]])
-              raise KeyError.new "Template name is already in use within pack! (`#{data[:name]}`)"
+            t_provider = data.fetch(:args, :provider, :aws)
+            if(templates.get(t_provider, data[:name]))
+              raise KeyError.new "Template name is already in use within pack! (`#{data[:name]}` -> `#{t_provider}`)"
             end
-            templates[data[:name]] = data.merge(
-              :type => :template,
-              :path => file,
-              :serialized => !file.end_with?('.rb')
+            templates.set(t_provider, data[:name],
+              data.merge(
+                :type => :template,
+                :path => file,
+                :serialized => !file.end_with?('.rb')
+              )
             )
           end
         end
@@ -343,10 +367,11 @@ class SparkleFormation
               type, name = path.slice(path.size - 2, 2)
               collection = send(type)
             end
-            if(collection[name])
-              raise KeyError.new "#{key.capitalize} name is already in use within pack! (`#{name}`)"
+            i_provider = item.fetch(:args, :provider, :aws)
+            if(collection.get(i_provider, name))
+              raise KeyError.new "#{key.capitalize} name is already in use within pack! (`#{name}` -> #{i_provider})"
             end
-            collection[name] = item
+            collection.set(i_provider, name, item)
           end
         end
       end

--- a/lib/sparkle_formation/sparkle_attribute.rb
+++ b/lib/sparkle_formation/sparkle_attribute.rb
@@ -70,27 +70,30 @@ class SparkleFormation
     # @param name [String, Symbol] dynamic name
     # @param args [Object] argument list for dynamic
     # @return [self]
-    def dynamic!(name, *args, &block)
+    def _dynamic(name, *args, &block)
       SparkleFormation.insert(name, self, *args, &block)
     end
+    alias_method :dynamic!, :_dynamic
 
     # Registry insertion helper method
     #
     # @param name [String, Symbol] name of registry item
     # @param args [Object] argument list for registry
     # @return [self]
-    def registry!(name, *args)
+    def _registry(name, *args)
       SparkleFormation.registry(name, self, *args)
     end
+    alias_method :registry!, :_registry
 
     # Stack nesting helper method
     #
     # @param template [String, Symbol] template to nest
     # @param args [String, Symbol] stringified and underscore joined for name
     # @return [self]
-    def nest!(template, *args, &block)
+    def _nest(template, *args, &block)
       SparkleFormation.nest(template, self, *args, &block)
     end
+    alias_method :nest!, :_nest
 
     # Format the provided key. If symbol type is provided
     # formatting is forced. Otherwise the default formatting

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -200,7 +200,8 @@ class SparkleFormation
     # @return [SparkleStruct]
     def registry(registry_name, struct, *args)
       __t_stringish(registry_name)
-      reg = struct._self.sparkle.get(:registry, registry_name)
+      opts = args.detect{|item| item.is_a?(Hash)} || {}
+      reg = struct._self.sparkle.get(:registry, registry_name, opts[:provider])
       struct.instance_exec(*args, &reg[:block])
     end
 
@@ -214,7 +215,9 @@ class SparkleFormation
       __t_stringish(dynamic_name)
       result = false
       begin
-        dyn = struct._self.sparkle.get(:dynamic, dynamic_name)
+        opts = args.detect{|i| i.is_a?(Hash)} || {}
+        dyn = struct._self.sparkle.get(:dynamic, dynamic_name, opts[:provider])
+        opts = nil
         raise dyn if dyn.is_a?(Exception)
         dyn.monochrome.each do |dynamic_item|
           if(result)
@@ -234,7 +237,7 @@ class SparkleFormation
         result = builtin_insert(dynamic_name, struct, *args, &block)
         unless(result)
           message = "Failed to locate requested dynamic block for insertion: #{dynamic_name} " \
-          "(valid: #{struct._self.sparkle.dynamics[struct._self.sparkle.provider].keys.sort.join(', ')})"
+            "(valid: #{struct._self.sparkle.dynamics.fetch(struct._self.sparkle.provider, {}).keys.sort.join(', ')})"
           if(struct._self.provider_resources && struct._self.provider_resources.registry.keys.size > 1)
             t_name = struct._self.provider_resources.registry.keys.first
             valid_t_name = Bogo::Utility.snake(
@@ -637,7 +640,7 @@ class SparkleFormation
   #
   # @param args [String, Symbol] Symbol component names or String paths
   # @return [self]
-  def load(*args)
+  def load(*args, &user_block)
     args.each do |thing|
       if(thing.is_a?(String))
         # NOTE: This needs to be deprecated and removed
@@ -647,6 +650,9 @@ class SparkleFormation
       else
         composition.new_component(thing)
       end
+    end
+    if(block_given?)
+      block(user_block)
     end
     self
   end

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -234,7 +234,7 @@ class SparkleFormation
         result = builtin_insert(dynamic_name, struct, *args, &block)
         unless(result)
           message = "Failed to locate requested dynamic block for insertion: #{dynamic_name} " \
-          "(valid: #{struct._self.sparkle.dynamics.keys.sort.join(', ')})"
+          "(valid: #{struct._self.sparkle.dynamics[struct._self.sparkle.provider].keys.sort.join(', ')})"
           if(struct._self.provider_resources && struct._self.provider_resources.registry.keys.size > 1)
             t_name = struct._self.provider_resources.registry.keys.first
             valid_t_name = Bogo::Utility.snake(
@@ -538,6 +538,7 @@ class SparkleFormation
       if(Provider.const_defined?(provider_klass))
         extend Provider.const_get(provider_klass)
       end
+      sparkle.provider = val
       @provider
     else
       @provider = nil

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -271,7 +271,7 @@ class SparkleFormation
       [template, *args].compact.each do |item|
         __t_stringish(item)
       end
-      to_nest = struct._self.sparkle.get(:template, template)
+      to_nest = struct._self.sparkle.get(:template, template, options[:provider])
       resource_name = template.to_s.gsub('__', '_')
       unless(args.empty?)
         resource_name = [

--- a/test/specs/packs/valid_pack/components/base-heat.rb
+++ b/test/specs/packs/valid_pack/components/base-heat.rb
@@ -1,0 +1,3 @@
+SparkleFormation.component(:base, :provider => :heat) do
+  heat_component true
+end

--- a/test/specs/packs/valid_pack/components/base.rb
+++ b/test/specs/packs/valid_pack/components/base.rb
@@ -1,3 +1,3 @@
 SparkleFormation.component(:base) do
-  testing true
+  aws_component true
 end

--- a/test/specs/packs/valid_pack/dynamics/base-heat.rb
+++ b/test/specs/packs/valid_pack/dynamics/base-heat.rb
@@ -1,0 +1,3 @@
+SparkleFormation.dynamic(:base, :provider => :heat) do |n, c={}|
+  heat_dynamic true
+end

--- a/test/specs/packs/valid_pack/dynamics/base.rb
+++ b/test/specs/packs/valid_pack/dynamics/base.rb
@@ -1,3 +1,3 @@
 SparkleFormation.dynamic(:base) do |n, c={}|
-  testing true
+  aws_dynamic true
 end

--- a/test/specs/packs/valid_pack/registry/base-heat.rb
+++ b/test/specs/packs/valid_pack/registry/base-heat.rb
@@ -1,0 +1,3 @@
+SfnRegistry.register(:base, :provider => :heat) do |*_|
+  'heat'
+end

--- a/test/specs/packs/valid_pack/registry/base.rb
+++ b/test/specs/packs/valid_pack/registry/base.rb
@@ -1,3 +1,3 @@
 SfnRegistry.register(:base) do |*_|
-  :fubar
+  'aws'
 end

--- a/test/specs/packs/valid_pack/registry/shared.rb
+++ b/test/specs/packs/valid_pack/registry/shared.rb
@@ -1,0 +1,3 @@
+SfnRegistry.register(:shared, :provider => :shared) do
+  'shared'
+end

--- a/test/specs/packs/valid_pack/stack-heat.rb
+++ b/test/specs/packs/valid_pack/stack-heat.rb
@@ -1,6 +1,6 @@
-SparkleFormation.new(:stack).load(:base) do
-  aws_template true
+SparkleFormation.new(:stack, :provider => :heat) do
+  heat_template true
   dynamic!(:base)
   registry registry!(:base)
   shared_item registry!(:shared, :provider => :shared)
-end
+end.load(:base)

--- a/test/specs/sparkle_collection_spec.rb
+++ b/test/specs/sparkle_collection_spec.rb
@@ -136,4 +136,41 @@ describe SparkleFormation::SparkleCollection do
 
   end
 
+  describe 'Provider specific loading' do
+    before do
+      @collection = SparkleFormation::SparkleCollection.new
+      @collection.set_root(
+        SparkleFormation::Sparkle.new(
+          :root => File.join(
+            File.dirname(__FILE__), 'packs', 'valid_pack'
+          )
+        )
+      )
+      @collection
+    end
+
+    it 'should load AWS by default' do
+      template = @collection.get(:template, :stack)
+      template = SparkleFormation.compile(template[:path], :sparkle)
+      template.sparkle.apply @collection
+      result = template.dump.to_smash
+      result['AwsTemplate'].must_equal true
+      result['AwsDynamic'].must_equal true
+      result['Registry'].must_equal 'aws'
+      result['SharedItem'].must_equal 'shared'
+    end
+
+    it 'should load HEAT when defined as provider' do
+      template = @collection.get(:template, :stack, :heat)
+      template = SparkleFormation.compile(template[:path], :sparkle)
+      template.sparkle.apply @collection
+      result = template.dump.to_smash
+      result['heat_template'].must_equal true
+      result['heat_dynamic'].must_equal true
+      result['registry'].must_equal 'heat'
+      result['shared_item'].must_equal 'shared'
+    end
+
+  end
+
 end

--- a/test/specs/template_spec.rb
+++ b/test/specs/template_spec.rb
@@ -42,7 +42,7 @@ describe SparkleFormation do
         )
       )
       result = template.dump.to_smash
-      result.get('Resources', 'PackTemplate', 'Properties', 'Stack', 'Testing').must_equal true
+      result.get('Resources', 'PackTemplate', 'Properties', 'Stack', 'AwsDynamic').must_equal true
     end
 
   end


### PR DESCRIPTION
Allows for common template/dynamic/component/registry names made unique
by combining the target provider. This will allow for common naming among
files but will restrict available loading based on set provider or explicitly
define provider when requesting from pack or collection.