### PR TITLE
Implement import_value as AWS helper function

### DIFF
--- a/lib/sparkle_formation/sparkle_attribute/aws.rb
+++ b/lib/sparkle_formation/sparkle_attribute/aws.rb
@@ -37,6 +37,17 @@ class SparkleFormation
       alias_method :_ref, :_cf_ref
       alias_method :ref!, :_cf_ref
 
+      # ValueImport generator
+      #
+      # @param thing [String, String] value import
+      # @return [Hash]
+      def _cf_value_import(thing)
+        __t_stringish(thing)
+        {'Fn::ImportValue' => __attribute_key(thing)}
+      end
+      alias_method :_import_value, :_cf_value_import
+      alias_method :import_value!, :_cf_value_import
+
       # @overload _cf_map(map_name, top_level_key, second_level_key)
       #   Fn::FindInMap generator
       #   @param map_name [String, Symbol] name of map

--- a/test/specs/sparkle_attribute/aws_spec.rb
+++ b/test/specs/sparkle_attribute/aws_spec.rb
@@ -31,6 +31,13 @@ describe SparkleFormation::SparkleAttribute::Aws do
     end.dump.must_equal 'Thing' => {'Ref' => 'Item'}
   end
 
+  it 'should generate Fn::ImportValue' do
+    @sfn.overrides do
+      thing import_value!('MyUniqueOutput')
+    end.dump.
+      must_equal 'Thing' => {'Fn::ImportValue' => 'MyUniqueOutput'}
+  end
+
   it 'should generate Fn::FindInMap' do
     @sfn.overrides do
       thing find_in_map!('MyMap', ref!('MyKey'), 'SubKey')


### PR DESCRIPTION
Implemented test cases and added ImportValue as a function.

Reference:
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html
- https://aws.amazon.com/blogs/aws/aws-cloudformation-update-yaml-cross-stack-references-simplified-substitution/
