### PR TITLE
Fix parameter based push into nested stacks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,8 @@ Style/BlockDelimiters:
   Enabled: false
 Style/DoubleNegation:
   Enabled: false
+Style/NegatedIf:
+  Enabled: false
 Lint/AssignmentInCondition:
   Enabled: false
 Style/UnlessElse:

--- a/lib/sparkle_formation/provider/aws.rb
+++ b/lib/sparkle_formation/provider/aws.rb
@@ -57,7 +57,7 @@ class SparkleFormation
           unless(stack.root?)
             stack.compile.parameters.keys!.each do |parameter_name|
               next if stack.compile.parameters.set!(parameter_name).stack_unique == true
-              if(!stack.parent.compile.parameters.set!(parameter_name).nil?)
+              if(!stack.parent.compile.parameters.data![parameter_name].nil?)
                 resource.properties.parameters.set!(parameter_name, resource.ref!(parameter_name))
               elsif(output_name = output_matched?(parameter_name, outputs.keys))
                 next if outputs[output_name] == stack

--- a/test/rspecs/acceptance/deep_nesting/aws/parameter_push_rspec.rb
+++ b/test/rspecs/acceptance/deep_nesting/aws/parameter_push_rspec.rb
@@ -1,0 +1,108 @@
+require_relative '../../../../rspecs'
+
+RSpec.describe 'Acceptance -> Deep Nesting -> Aws' do
+  describe '-> Deep nesting parameter push' do
+
+    let(:root) do
+      SparkleFormation.new(:root) do
+        parameters.test_param.type 'String'
+      end
+    end
+
+    let(:with_param) do
+      SparkleFormation.new(:with_param) do
+        parameters.test_param.type 'String'
+      end
+    end
+
+    let(:with_param_2) do
+      SparkleFormation.new(:with_param_2) do
+        parameters.test_param.type 'String'
+      end
+    end
+
+    let(:without_param) do
+      SparkleFormation.new(:without_param) do
+        parameters.different_param.type 'String'
+      end
+    end
+
+    context 'with single nested parameter path' do
+      before do
+        prm = with_param
+        root.overrides do
+          resources.nested do
+            type _self.stack_resource_type
+            properties.stack prm
+          end
+        end
+        prm.parent = root
+      end
+
+      it 'should map root parameter to nested stack' do
+        root.apply_deep_nesting
+        result = root.sparkle_dump.to_smash
+        nested_params = result.get('Resources', 'Nested', 'Properties', 'Parameters')
+        expect(nested_params).to eq('TestParam' => {'Ref' => 'TestParam'})
+      end
+
+      context 'with double nested parameter path' do
+        before do
+          prm2 = with_param_2
+          with_param.overrides do
+            resources.nested2 do
+              type _self.stack_resource_type
+              properties.stack prm2
+            end
+          end
+          prm2.parent = with_param
+        end
+
+        it 'should map root parameter to first nested stack' do
+          root.apply_deep_nesting
+          result = root.sparkle_dump.to_smash
+          nested_params = result.get('Resources', 'Nested', 'Properties', 'Parameters')
+          expect(nested_params).to eq('TestParam' => {'Ref' => 'TestParam'})
+        end
+
+        it 'should map root parameter to second nested stack' do
+          root.apply_deep_nesting
+          result = root.sparkle_dump.to_smash
+          nested_params = result.get(
+            'Resources', 'Nested', 'Properties', 'Stack',
+            'Resources', 'Nested2', 'Properties', 'Parameters'
+          )
+          expect(nested_params).to eq('TestParam' => {'Ref' => 'TestParam'})
+        end
+      end
+    end
+
+    context 'with double nested no parameter path' do
+      before do
+        wo_prm = without_param
+        prm = with_param
+        wo_prm.overrides do
+          resources.nested2 do
+            type _self.stack_resource_type
+            properties.stack prm
+          end
+        end
+        root.overrides do
+          resources.nested do
+            type _self.stack_resource_type
+            properties.stack wo_prm
+          end
+        end
+        wo_prm.parent = root
+        prm.parent = wo_prm
+      end
+
+      it 'should map root parameter to first nested stack' do
+        root.apply_deep_nesting
+        result = root.sparkle_dump.to_smash
+        nested_params = result.get('Rsources', 'Nested', 'Properties', 'Parameters')
+        expect(nested_params).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes parameter pushing into nested stacks to not litter parameter artifacts in ancestor stacks when parameter is non-existent. Also adds some rspec behavior coverage on nested parameter pushing.