### PR TITLE
Allow remap of variable objects

### DIFF
--- a/lib/sparkle_formation.rb
+++ b/lib/sparkle_formation.rb
@@ -5,6 +5,7 @@ require 'attribute_struct'
 # Unicorns and rainbows
 class SparkleFormation
   autoload :Aws, 'sparkle_formation/aws'
+  autoload :AzureVariableStruct, 'sparkle_formation/function_struct'
   autoload :Composition, 'sparkle_formation/composition'
   autoload :Error, 'sparkle_formation/error'
   autoload :FunctionStruct, 'sparkle_formation/function_struct'

--- a/lib/sparkle_formation/sparkle_attribute/azure.rb
+++ b/lib/sparkle_formation/sparkle_attribute/azure.rb
@@ -69,7 +69,6 @@ class SparkleFormation
         'uri',
         'deployment',
         'parameters',
-        'variables',
         'listKeys',
         'providers',
         'reference',
@@ -102,6 +101,16 @@ class SparkleFormation
         end
         alias_method "#{f_name}!".to_sym, "_#{f_name}".to_sym
       end
+
+      # Variables generator
+      #
+      # @return [SparkleFormation::AzureVariableStruct]
+      def _variables(*args)
+        x = ::SparkleFormation::AzureVariableStruct.new('variables', *args)
+        x._fn_context = self
+        x
+      end
+      alias_method :variables!, :_variables
 
       # @overload _resource_id(resource_name)
       #   Customized resourceId generator that will perform automatic

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -755,14 +755,16 @@ class SparkleFormation
     if(compile[:resources])
       compile.resources.keys!.map do |key|
         if(stack_resource_type?(compile.resources[key].type))
-          result = [compile.resources[key].properties.stack]
-          if(args.include?(:with_resource))
-            result.push(compile[:resources][key])
+          if(compile.resources[key].properties.stack.is_a?(::SparkleFormation))
+            result = [compile.resources[key].properties.stack]
+            if(args.include?(:with_resource))
+              result.push(compile[:resources][key])
+            end
+            if(args.include?(:with_name))
+              result.push(key)
+            end
+            result.size == 1 ? result.first : result
           end
-          if(args.include?(:with_name))
-            result.push(key)
-          end
-          result.size == 1 ? result.first : result
         end
       end.compact
     else


### PR DESCRIPTION
Allows remap of variable objects to match the correct casing for the invocation. Finally fixes #192.