### PR TITLE
Support non-stringish keys

### DIFF
--- a/lib/sparkle_formation/error.rb
+++ b/lib/sparkle_formation/error.rb
@@ -8,6 +8,9 @@ class SparkleFormation
     # Inheritance error
     class CircularInheritance < Error; end
 
+    # Found resource improperly constructed
+    class InvalidResource < Error; end
+
     # File not found error
     class NotFound < KeyError
       attr_reader :name

--- a/lib/sparkle_formation/function_struct.rb
+++ b/lib/sparkle_formation/function_struct.rb
@@ -29,8 +29,8 @@ class SparkleFormation
       end
     end
 
-    # Create a clone of this instance
-    def _clone
+    # # Create a clone of this instance
+    def _clone(*_)
       _klass.new(_fn_name, *_fn_args)
     end
 

--- a/lib/sparkle_formation/function_struct.rb
+++ b/lib/sparkle_formation/function_struct.rb
@@ -29,6 +29,32 @@ class SparkleFormation
       end
     end
 
+    # Create a clone of this instance
+    def _clone
+      _klass.new(_fn_name, *_fn_args)
+    end
+
+    # @return [Numeric] hash value for instance
+    def hash
+      _dump.hash
+    end
+
+    # @return [TrueClass, FalseClass]
+    def eql?(_other)
+      if(_other.respond_to?(:_dump) && _other.respond_to?(:_parent))
+        ::MultiJson.dump(_dump).hash ==
+          ::MultiJson.dump(_other._dump).hash &&
+          _parent == _other._parent
+      else
+        false
+      end
+    end
+
+    # @return [TrueClass, FalseClass]
+    def ==(_other)
+      eql?(_other)
+    end
+
     # @return [False] functions are never nil
     def nil?
       false

--- a/lib/sparkle_formation/provider.rb
+++ b/lib/sparkle_formation/provider.rb
@@ -8,6 +8,7 @@ class SparkleFormation
     autoload :Azure, 'sparkle_formation/provider/azure'
     autoload :Google, 'sparkle_formation/provider/google'
     autoload :Heat, 'sparkle_formation/provider/heat'
+    autoload :OpenStack, 'sparkle_formation/provider/heat'
     autoload :Terraform, 'sparkle_formation/provider/terraform'
 
   end

--- a/lib/sparkle_formation/provider/heat.rb
+++ b/lib/sparkle_formation/provider/heat.rb
@@ -159,5 +159,6 @@ class SparkleFormation
       end
 
     end
+    OpenStack = Heat
   end
 end

--- a/lib/sparkle_formation/sparkle_attribute.rb
+++ b/lib/sparkle_formation/sparkle_attribute.rb
@@ -31,6 +31,9 @@ class SparkleFormation
       unless(result)
         ::Kernel.raise NameError.new 'Failed to determine current resource name! (Check call location)'
       end
+      if(result.is_a?(::SparkleFormation::FunctionStruct))
+        result = result._clone
+      end
       result
     end
     alias_method :resource_name!, :_resource_name

--- a/lib/sparkle_formation/sparkle_attribute.rb
+++ b/lib/sparkle_formation/sparkle_attribute.rb
@@ -9,6 +9,7 @@ class SparkleFormation
     autoload :Azure, 'sparkle_formation/sparkle_attribute/azure'
     autoload :Google, 'sparkle_formation/sparkle_attribute/google'
     autoload :Heat, 'sparkle_formation/sparkle_attribute/heat'
+    autoload :OpenStack, 'sparkle_formation/sparkle_attribute/heat'
     autoload :Rackspace, 'sparkle_formation/sparkle_attribute/rackspace'
     autoload :Terraform, 'sparkle_formation/sparkle_attribute/terraform'
 

--- a/lib/sparkle_formation/sparkle_attribute/azure.rb
+++ b/lib/sparkle_formation/sparkle_attribute/azure.rb
@@ -126,6 +126,10 @@ class SparkleFormation
           resource = _root.resources.set!(r_name)
           if(resource.nil?)
             ::Kernel.raise ::SparkleFormation::Error::NotFound::Resource.new(:name => r_name)
+          elsif(resource.type.nil?)
+            ::Kernel.raise ::SparkleFormation::Error::InvalidResource.new(
+              "Resource `#{r_name}` provides no type information."
+            )
           else
             ::SparkleFormation::FunctionStruct.new(
               'resourceId',

--- a/lib/sparkle_formation/sparkle_attribute/heat.rb
+++ b/lib/sparkle_formation/sparkle_attribute/heat.rb
@@ -191,6 +191,6 @@ class SparkleFormation
       alias_method :stack_output!, :_stack_output
 
     end
-
+    OpenStack = Heat
   end
 end

--- a/lib/sparkle_formation/sparkle_attribute/heat.rb
+++ b/lib/sparkle_formation/sparkle_attribute/heat.rb
@@ -10,6 +10,9 @@ class SparkleFormation
 
       # Set customized struct behavior
       def self.included(klass)
+        if(klass.const_defined?(:CAMEL_KEYS))
+          klass.send(:remove_const, :CAMEL_KEYS)
+        end
         klass.const_set(:CAMEL_KEYS, false)
       end
 

--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -309,12 +309,16 @@ class SparkleFormation
       if(struct._self.provider_resources && lookup_key = struct._self.provider_resources.registry_key(dynamic_name))
         _name, _config = *args
         _config ||= {}
-        __t_stringish(_name)
         __t_hashish(_config)
-        resource_name = [
-          _name,
-          _config.fetch(:resource_name_suffix, dynamic_name)
-        ].compact.join('_').to_sym
+        unless(_name.is_a?(SparkleFormation::FunctionStruct))
+          __t_stringish(_name)
+          resource_name = [
+            _name,
+            _config.fetch(:resource_name_suffix, dynamic_name)
+          ].compact.join('_').to_sym
+        else
+          resource_name = _name._root
+        end
         _config.delete(:resource_name_suffix)
         new_resource = struct.resources.set!(resource_name)
         new_resource.type lookup_key
@@ -916,7 +920,8 @@ class SparkleFormation
         outputs = Smash.new
       end
       nested_stacks.each do |nested_stack|
-        outputs = nested_stack.collect_outputs(:force).merge(outputs)
+        n_stack = nested_stack.is_a?(self.class) ? nested_stack : nested_stack._self
+        outputs = n_stack.collect_outputs(:force).merge(outputs)
       end
       outputs
     else

--- a/lib/sparkle_formation/sparkle_struct.rb
+++ b/lib/sparkle_formation/sparkle_struct.rb
@@ -26,6 +26,8 @@ class SparkleFormation
       include SparkleAttribute
       include SparkleAttribute::Heat
     end
+    OpenStack = Heat
+    Rackspace = Heat
     # Rackspace specific struct
     class Rackspace < SparkleStruct
       include SparkleAttribute

--- a/lib/sparkle_formation/sparkle_struct.rb
+++ b/lib/sparkle_formation/sparkle_struct.rb
@@ -108,17 +108,22 @@ class SparkleFormation
     # Override to inspect result value and fetch root if value is a
     # FunctionStruct
     def method_missing(sym, *args, &block)
-      if(sym.to_s.start_with?('_') || sym.to_s.end_with?('!'))
-        ::Kernel.raise ::NoMethodError.new "Undefined method `#{sym}` for #{_klass.name}"
+      if(sym.is_a?(::String) || sym.is_a?(::Symbol))
+        if(sym.to_s.start_with?('_') || sym.to_s.end_with?('!'))
+          ::Kernel.raise ::NoMethodError.new "Undefined method `#{sym}` for #{_klass.name}"
+        end
       end
       super(*[sym, *args], &block)
-      if((s = sym.to_s).end_with?('='))
-        s.slice!(-1, s.length)
-        sym = s
+      if(sym.is_a?(::String) || sym.is_a?(::Symbol))
+        if((s = sym.to_s).end_with?('='))
+          s.slice!(-1, s.length)
+          sym = s
+        end
+        sym = _process_key(sym)
+      else
+        sym = function_bubbler(sym)
       end
-      sym = _process_key(sym)
       @table[sym] = function_bubbler(@table[sym])
-      @table[sym]
     end
 
     # @return [Class]

--- a/lib/sparkle_formation/sparkle_struct.rb
+++ b/lib/sparkle_formation/sparkle_struct.rb
@@ -124,6 +124,11 @@ class SparkleFormation
         sym = function_bubbler(sym)
       end
       @table[sym] = function_bubbler(@table[sym])
+      # Always reset parent in case this is a clone
+      if(@table[sym].is_a?(::AttributeStruct))
+        @table[sym]._parent(self)
+      end
+      @table[sym]
     end
 
     # @return [Class]

--- a/sparkle_formation.gemspec
+++ b/sparkle_formation.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license = 'Apache-2.0'
   s.require_path = 'lib'
   s.required_ruby_version = '>= 2.1'
-  s.add_runtime_dependency 'attribute_struct', '>= 0.3.0', '< 0.5'
+  s.add_runtime_dependency 'attribute_struct', '>= 0.3.5', '< 0.5'
   s.add_runtime_dependency 'multi_json'
   s.add_runtime_dependency 'bogo'
   s.add_development_dependency 'minitest'

--- a/test/rspecs/sparkle_rspec.rb
+++ b/test/rspecs/sparkle_rspec.rb
@@ -2,6 +2,7 @@ require_relative '../rspecs'
 
 RSpec.describe SparkleFormation::Sparkle do
   let(:root_dir){ Dir.mktmpdir('sparkleformation-sparkle-rspec') }
+  after{ FileUtils.rm_rf(root_dir) }
 
   context "with pack defined" do
     let(:instance){ described_class.new(:root => root_dir) }


### PR DESCRIPTION
Adds support for non-string like values used as keys within the underlying data set. This allows for using AttributeStruct type instances as a key to support dynamic keying where providers may allow using intrinsic functions as identifiers (as seen within ARM templates for an example).