### PR TITLE
Ensure that compile_state param key reference is a symbol

### DIFF
--- a/lib/sparkle_formation/sparkle_formation.rb
+++ b/lib/sparkle_formation/sparkle_formation.rb
@@ -755,7 +755,7 @@ class SparkleFormation
     storage_compile_state = Smash.new
     parameters.each do |param_key, param_config|
       if(param_config.fetch(:type, 'string').to_s.downcase.to_sym != :complex)
-        storage_compile_state[param_key] = compile_state[param_key]
+        storage_compile_state[param_key.to_sym] = compile_state[param_key.to_sym]
       end
     end
     compiled.outputs.compile_state.value MultiJson.dump(storage_compile_state)


### PR DESCRIPTION
Our test suite picked up what looks like a regression in the recent complex compile_state params support implementation. In a use case where ```:inherit``` is used in a template, the ```compile``` flow forks towards ```inherit_from``` method and  goes through ```extract_template_data``` in there the ```parameters``` hash gets passed into ```to_smash``` https://github.com/sparkleformation/sparkle_formation/blob/develop/lib/sparkle_formation/sparkle_formation.rb#L518
```to_smash``` method converts parameters hash keys to strings away from original symbols; when subsequently ```compile_state[param_key]``` is used in the assignment (refer to PR's diff) the assigned value is nil because ```compile_state``` has keys that are symbols, but the param_key reference is a string.
This seems to be the case only with the :inherit flow and hasn't surfaced till ```compile_state``` param key reference was used explicitly. 

@chrisroberts I am not sure how to add a test for this within the existing rspec/minitest setup, but if you'd like to give some guidance I can give it a shot.

Thank you.