### PR TITLE
Fix deprecation warnings caused by Ruby 2.4.0 deprecations.

### DIFF
--- a/lib/sparkle_formation/sparkle.rb
+++ b/lib/sparkle_formation/sparkle.rb
@@ -108,9 +108,18 @@ class SparkleFormation
 
       # NOTE: Enable access to top level constants but do not
       # include deprecated constants to prevent warning outputs
+      deprecated_constants = [
+        :Config,
+        :TimeoutError,
+        :Fixnum,
+        :Bignum,
+        :NIL,
+        :TRUE,
+        :FALSE
+      ]
       ::Object.constants.each do |const|
         unless(self.const_defined?(const)) # rubocop:disable Style/RedundantSelf
-          next if const == :Config || const == :TimeoutError
+          next if deprecated_constants.include?(const)
           self.const_set(const, ::Object.const_get(const)) # rubocop:disable Style/RedundantSelf
         end
       end


### PR DESCRIPTION
After upgrading to Ruby 2.4.0 deprecation warning started to show up in `sfn` calls:
```
012851:infrastructure chrmiller$ bundle exec sfn validate  -f ./redacted.rb  -d --upload-root-template
/Users/chrmiller/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sparkle_formation-3.0.24/lib/sparkle_formation/sparkle.rb:114: warning: constant ::Fixnum is deprecated
/Users/chrmiller/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sparkle_formation-3.0.24/lib/sparkle_formation/sparkle.rb:114: warning: constant ::Bignum is deprecated
/Users/chrmiller/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sparkle_formation-3.0.24/lib/sparkle_formation/sparkle.rb:114: warning: constant ::NIL is deprecated
/Users/chrmiller/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sparkle_formation-3.0.24/lib/sparkle_formation/sparkle.rb:114: warning: constant ::TRUE is deprecated
/Users/chrmiller/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sparkle_formation-3.0.24/lib/sparkle_formation/sparkle.rb:114: warning: constant ::FALSE is deprecated
...
```
This is a naively removes the warnings by not creating the constants in the module that's causing them.