### PR TITLE
Updated for new deprecated constants

### DIFF
--- a/lib/sparkle_formation/sparkle.rb
+++ b/lib/sparkle_formation/sparkle.rb
@@ -110,7 +110,8 @@ class SparkleFormation
       # include deprecated constants to prevent warning outputs
       ::Object.constants.each do |const|
         unless(self.const_defined?(const)) # rubocop:disable Style/RedundantSelf
-          next if const == :Config || const == :TimeoutError
+          deprecated_constants = %i[Bignum Config FALSE Fixnum NIL TimeoutError TRUE]
+          next if deprecated_constants.include? const
           self.const_set(const, ::Object.const_get(const)) # rubocop:disable Style/RedundantSelf
         end
       end


### PR DESCRIPTION
Adds additional top level constants to ignore to prevent the following warnings.

```
C:/Tools/ruby-2.4.1/lib/ruby/gems/2.4.0/gems/sparkle_formation-3.0.24/lib/sparkle_formation/sparkle.rb:114: warning: constant ::Fixnum is deprecated
C:/Tools/ruby-2.4.1/lib/ruby/gems/2.4.0/gems/sparkle_formation-3.0.24/lib/sparkle_formation/sparkle.rb:114: warning: constant ::Bignum is deprecated
C:/Tools/ruby-2.4.1/lib/ruby/gems/2.4.0/gems/sparkle_formation-3.0.24/lib/sparkle_formation/sparkle.rb:114: warning: constant ::NIL is deprecated
C:/Tools/ruby-2.4.1/lib/ruby/gems/2.4.0/gems/sparkle_formation-3.0.24/lib/sparkle_formation/sparkle.rb:114: warning: constant ::TRUE is deprecated
C:/Tools/ruby-2.4.1/lib/ruby/gems/2.4.0/gems/sparkle_formation-3.0.24/lib/sparkle_formation/sparkle.rb:114: warning: constant ::FALSE is deprecated
```