### PR TITLE
Add failing test for loading dynamics locally and from an external sparkle pack

### DIFF
--- a/test/specs/packs/base_pack/a.rb
+++ b/test/specs/packs/base_pack/a.rb
@@ -1,0 +1,5 @@
+::SparkleFormation::SparklePack.register!('external_sparkle_pack', File.join(File.dirname(__FILE__), '..', 'external_sparkle_pack'))
+add_on_pack = ::SparkleFormation::SparklePack.new(:name => 'external_sparkle_pack')
+SparkleFormation.new(:a, sparkle: add_on_pack) do
+  dynamic!(:add_on)
+end

--- a/test/specs/packs/base_pack/dynamics/base.rb
+++ b/test/specs/packs/base_pack/dynamics/base.rb
@@ -1,0 +1,3 @@
+SparkleFormation.dynamic(:base) do |name, args|
+  outputs.template.value 'BASE'
+end

--- a/test/specs/packs/base_pack/stack.rb
+++ b/test/specs/packs/base_pack/stack.rb
@@ -1,6 +1,3 @@
-::SparkleFormation::SparklePack.register!('external_sparkle_pack', File.join(File.dirname(__FILE__), '..', 'external_sparkle_pack'))
-add_on_pack = ::SparkleFormation::SparklePack.new(:name => 'external_sparkle_pack')
-SparkleFormation.new(:stack, :sparkle => add_on_pack) do
-  dynamic!(:add_on)
+SparkleFormation.new(:stack) do
   dynamic!(:base)
 end

--- a/test/specs/packs/base_pack/stack.rb
+++ b/test/specs/packs/base_pack/stack.rb
@@ -1,0 +1,6 @@
+::SparkleFormation::SparklePack.register!('external_sparkle_pack', File.join(File.dirname(__FILE__), '..', 'external_sparkle_pack'))
+add_on_pack = ::SparkleFormation::SparklePack.new(:name => 'external_sparkle_pack')
+SparkleFormation.new(:stack, :sparkle => add_on_pack) do
+  dynamic!(:add_on)
+  dynamic!(:base)
+end

--- a/test/specs/packs/external_sparkle_pack/dynamics/add_on.rb
+++ b/test/specs/packs/external_sparkle_pack/dynamics/add_on.rb
@@ -1,0 +1,3 @@
+SparkleFormation.dynamic(:add_on) do |name, args|
+  outputs.name.value 'ADD_ON'
+end

--- a/test/specs/sparkle_spec.rb
+++ b/test/specs/sparkle_spec.rb
@@ -25,6 +25,16 @@ describe SparkleFormation::Sparkle do
     end
   end
 
+  describe 'sparkle pack loads dynamics from itself and another pack' do
+    before do
+      @template = SparkleFormation.compile(File.join(File.dirname(__FILE__), 'packs/base_pack/stack.rb'), :sparkle)
+    end
+
+    it 'should be able to compile a stack with the dynamics' do
+      @template.to_json.must_be_kind_of String
+    end
+  end
+
   describe 'invalid name collision pack' do
     it 'should raise a KeyError on duplicate template name' do
       -> {

--- a/test/specs/sparkle_spec.rb
+++ b/test/specs/sparkle_spec.rb
@@ -27,7 +27,7 @@ describe SparkleFormation::Sparkle do
 
   describe 'sparkle pack loads dynamics from itself and another pack' do
     before do
-      ::SparkleFormation::SparklePack.register!('base_pack',  File.join(File.dirname(__FILE__), 'packs/base_pack'))
+      ::SparkleFormation::SparklePack.register!('base_pack', File.join(File.dirname(__FILE__), 'packs/base_pack'))
       @root_pack = ::SparkleFormation::SparklePack.new(:name => 'base_pack')
       ::SparkleFormation.sparkle_path = File.join(File.dirname(__FILE__), 'packs/base_pack')
       @template = ::SparkleFormation.compile(File.join(File.dirname(__FILE__), 'packs/base_pack/stack.rb'), :sparkle => @root_pack)

--- a/test/specs/sparkle_spec.rb
+++ b/test/specs/sparkle_spec.rb
@@ -27,7 +27,10 @@ describe SparkleFormation::Sparkle do
 
   describe 'sparkle pack loads dynamics from itself and another pack' do
     before do
-      @template = SparkleFormation.compile(File.join(File.dirname(__FILE__), 'packs/base_pack/stack.rb'), :sparkle)
+      ::SparkleFormation::SparklePack.register!('base_pack',  File.join(File.dirname(__FILE__), 'packs/base_pack'))
+      @root_pack = ::SparkleFormation::SparklePack.new(:name => 'base_pack')
+      ::SparkleFormation.sparkle_path = File.join(File.dirname(__FILE__), 'packs/base_pack')
+      @template = ::SparkleFormation.compile(File.join(File.dirname(__FILE__), 'packs/base_pack/stack.rb'), :sparkle => @root_pack)
     end
 
     it 'should be able to compile a stack with the dynamics' do


### PR DESCRIPTION
This creates a failing test that replicates the issue explained in #239

Locally it returns:

```
  1) Error:
SparkleFormation::Sparkle::sparkle pack loads dynamics from itself and another pack#test_0001_should be able to compile a stack with the dynamics:
RuntimeError: Failed to locate requested dynamic block for insertion: base (valid: add_on)
Builtin dynamics pattern `AWS::ApiGateway::Account` -> `:aws_api_gateway_account`
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/sparkle_formation.rb:253:in `rescue in insert'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/sparkle_formation.rb:220:in `insert'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/sparkle_attribute.rb:102:in `_dynamic'
    /Users/patrickrobinson/src/sparkle_formation/test/specs/packs/base_pack/stack.rb:5:in `block in compile'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/sparkle_formation.rb:122:in `instance_exec'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/sparkle_formation.rb:122:in `build'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/sparkle_formation.rb:730:in `block (2 levels) in compile'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/composition.rb:142:in `block in each'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/composition.rb:141:in `each'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/composition.rb:141:in `each'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/sparkle_formation.rb:726:in `block in compile'
    /Users/patrickrobinson/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bogo-0.2.10/lib/bogo/memoization.rb:64:in `memoize'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/sparkle_formation.rb:697:in `compile'
    /Users/patrickrobinson/src/sparkle_formation/lib/sparkle_formation/sparkle_formation.rb:995:in `to_json'
    /Users/patrickrobinson/src/sparkle_formation/test/specs/sparkle_spec.rb:34:in `block (3 levels) in <top (required)>'
```

Note if we rename `a.rb` to `z.rb` the tests pass

cc @gstib @chrisroberts 