### PR TITLE
Add missing AWS pseudo parameters

### DIFF
--- a/lib/sparkle_formation/sparkle_attribute/aws.rb
+++ b/lib/sparkle_formation/sparkle_attribute/aws.rb
@@ -427,6 +427,15 @@ class SparkleFormation
       alias_method :_tags, :_cf_tags
       alias_method :tags!, :_cf_tags
 
+      # URL suffix generator
+      #
+      # @return [Hash]
+      def _cf_url_suffix
+        _ref("AWS::URLSuffix")
+      end
+
+      alias_method :_url_suffix, :_cf_url_suffix
+      alias_method :url_suffix!, :_cf_url_suffix
 
       # Partition generator
       #

--- a/lib/sparkle_formation/sparkle_attribute/aws.rb
+++ b/lib/sparkle_formation/sparkle_attribute/aws.rb
@@ -426,6 +426,17 @@ class SparkleFormation
 
       alias_method :_tags, :_cf_tags
       alias_method :tags!, :_cf_tags
+
+
+      # Partition generator
+      #
+      # @return [Hash]
+      def _cf_partition
+        _ref("AWS::Partition")
+      end
+
+      alias_method :_partition, :_cf_partition
+      alias_method :partition!, :_cf_partition
     end
   end
 end

--- a/test/specs/sparkle_attribute/aws_spec.rb
+++ b/test/specs/sparkle_attribute/aws_spec.rb
@@ -175,6 +175,10 @@ describe SparkleFormation::SparkleAttribute::Aws do
     @attr.stack_name!.must_equal "Ref" => "AWS::StackName"
   end
 
+  it "should generate a partition ref" do
+    @attr.partition!.must_equal "Ref" => "AWS::Partition"
+  end
+
   it "should generate a depends on array" do
     @attr.depends_on!("ResourceOne", :resource_two).must_equal ["ResourceOne", "ResourceTwo"]
     @attr._dump.must_equal "DependsOn" => ["ResourceOne", "ResourceTwo"]

--- a/test/specs/sparkle_attribute/aws_spec.rb
+++ b/test/specs/sparkle_attribute/aws_spec.rb
@@ -179,6 +179,10 @@ describe SparkleFormation::SparkleAttribute::Aws do
     @attr.partition!.must_equal "Ref" => "AWS::Partition"
   end
 
+  it "should generate a URL suffix ref" do
+    @attr.url_suffix!.must_equal "Ref" => "AWS::URLSuffix"
+  end
+
   it "should generate a depends on array" do
     @attr.depends_on!("ResourceOne", :resource_two).must_equal ["ResourceOne", "ResourceTwo"]
     @attr._dump.must_equal "DependsOn" => ["ResourceOne", "ResourceTwo"]


### PR DESCRIPTION
This PR introduces 2 missing AWS pseudo parameters:

* Partition
* URLSuffix

Ref: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html