### PR TITLE
add the azure builting 'listAccountSas'

### DIFF
--- a/lib/sparkle_formation/sparkle_attribute/azure.rb
+++ b/lib/sparkle_formation/sparkle_attribute/azure.rb
@@ -75,6 +75,7 @@ class SparkleFormation
         "reference",
         "resourceGroup",
         "subscription",
+        "listAccountSas",
       ]
 
       # NOTE: Alias implementation disabled due to Ruby 2.3 __callee__ bug


### PR DESCRIPTION
This tiny PR adds the 'listAccountSas' azure builtin.  Is anything more required?