### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
+  - 3.0
 script: bundle exec rake

--- a/lib/sparkle_formation/sparkle.rb
+++ b/lib/sparkle_formation/sparkle.rb
@@ -167,6 +167,7 @@ class SparkleFormation
           :NIL,
           :TRUE,
           :FALSE,
+          :SortedSet,
         ]
         ::Object.constants.each do |const|
           unless self.const_defined?(const) # rubocop:disable Style/RedundantSelf


### PR DESCRIPTION
Running `sparkle_formation` on Ruby 3.0 results in the following runtime error.

```
RuntimeError: The `SortedSet` class has been extracted from the `set` library.You must use the `sorted_set` gem or other alternatives.
(eval):107:in `require'
(eval):107:in `const_get'
(eval):107:in `block (2 levels) in eval_wrapper'
(eval):104:in `each'
(eval):104:in `block in eval_wrapper'
./lib/sparkle_formation/sparkle.rb:68:in `class_eval'
./lib/sparkle_formation/sparkle.rb:68:in `block in eval_wrapper'
./lib/sparkle_formation/sparkle.rb:66:in `instance_exec'
./lib/sparkle_formation/sparkle.rb:66:in `eval_wrapper'
./lib/sparkle_formation/sparkle.rb:251:in `initialize'
------------------
--- Caused by: ---
LoadError: cannot load such file -- sorted_set
(eval):107:in `require'
```

Avoid this problem by not copying across the `SortedSet` constant in the eval wrapper.